### PR TITLE
chore(cursor): always use PR request template

### DIFF
--- a/.cursor/rules/pr-template.mdc
+++ b/.cursor/rules/pr-template.mdc
@@ -1,0 +1,39 @@
+---
+description: Always use the repository PR request template when opening a pull request
+alwaysApply: true
+---
+
+# Pull request template
+
+When opening a pull request (via `gh pr create` or any other method), **ALWAYS** use this repository's PR request template.
+
+## Template location
+
+Read and follow: `.github/pull_request_template.md`
+
+## Required behavior
+
+1. Before creating a PR, read `.github/pull_request_template.md`.
+2. Use that file as the **entire** PR body structure — do not invent a different layout.
+3. Fill in every section from the template:
+   - Summary
+   - Type of change (mark the relevant checkbox with `x`)
+   - How to test
+   - Checklist (mark items that apply / were verified)
+   - Related issues
+4. Pass the filled template as the PR body (e.g. `gh pr create --body` with a HEREDOC).
+5. Do not replace the template with a custom Summary/Test plan-only format unless the user explicitly asks to skip the template.
+
+## Example shape
+
+The PR body must match the template sections, for example:
+
+- **Summary**: what changed and why
+- **Type of change**: one checkbox marked, e.g. `- [x] Build / CI / tooling`
+- **How to test**: include the template's `go test ./... -race` command (and any extra steps)
+- **Checklist**: mark completed items; leave non-applicable items unchecked
+- **Related issues**: link issues or leave `-`
+
+Prefer creating the PR with:
+
+`gh pr create --title "..." --body "$(cat <<'EOF' ...filled template... EOF)"`


### PR DESCRIPTION
## Summary

Add an always-applied Cursor rule so agents fill `.github/pull_request_template.md` when opening pull requests, instead of inventing a custom PR body layout.

## Type of change

- [ ] Bug fix
- [ ] Refactor
- [ ] New feature
- [ ] Breaking change (describe impact below)
- [ ] Documentation only
- [x] Build / CI / tooling
- [ ] Dependency update

## How to test

```bash
go test ./... -race
```

1. Confirm `.cursor/rules/pr-template.mdc` exists with `alwaysApply: true`.
2. Confirm the rule points agents at `.github/pull_request_template.md` and requires all template sections.

## Checklist

- [x] `go test ./... -race` passes locally
- [ ] If you changed **routes, handlers, or models**: Swagger was regenerated (`swag init` / project `Makefile` `setup` target) and `docs/` is updated if required
- [ ] If you added or renamed **environment variables**: README and/or `.env` examples are updated
- [ ] If you changed **Docker or compose**: `docker compose build` (or `make build-docker`) still succeeds
- [x] No new secrets, credentials, or production keys committed

## Related issues

-


Made with [Cursor](https://cursor.com)