### PR TITLE
feat(auth): RBAC with roles in JWT claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository provides a template for building a RESTful API using Go with fea
 
 - RESTful API endpoints for CRUD operations.
 - JWT Authentication.
+- Role-based access control (RBAC) via JWT `role` claims (`user` / `admin`).
 - Rate Limiting (per-client fixed window via Redis; see `RATE_LIMIT_*`).
 - Swagger Documentation.
 - PostgreSQL database integration using GORM.
@@ -48,6 +49,7 @@ golang-rest-api-template/
 │  │  ├── books.go
 │  │  ├── books_test.go
 │  │  ├── book_routes_auth_test.go
+│  │  ├── admin_routes_test.go
 │  │  ├── main_test.go
 │  │  ├── probes.go
 │  │  ├── probes_test.go
@@ -57,7 +59,9 @@ golang-rest-api-template/
 │  │  └── user_test.go
 │  ├── auth
 │  │  ├── auth.go
-│  │  └── auth_test.go
+│  │  ├── auth_test.go
+│  │  ├── roles.go
+│  │  └── roles_test.go
 │  ├── cache
 │  │  ├── cache.go
 │  │  ├── cache_mock.go
@@ -74,6 +78,8 @@ golang-rest-api-template/
 │  │  ├── api_key_test.go
 │  │  ├── jwt_auth.go
 │  │  ├── jwt_auth_test.go
+│  │  ├── rbac.go
+│  │  ├── rbac_test.go
 │  │  ├── cors.go
 │  │  ├── logger.go
 │  │  ├── max_body.go
@@ -202,6 +208,7 @@ http://localhost:8001/swagger/index.html
 - `DELETE /api/v1/books/:id`: Delete a book.
 - `POST /api/v1/login`: Login.
 - `POST /api/v1/register`: Register a new user.
+- `GET /api/v1/admin/me`: Admin-only identity probe (API key + JWT with `role=admin`).
 - `GET /swagger/*`: Swagger UI (no `X-API-Key`).
 
 ### JSON responses
@@ -216,6 +223,8 @@ Under **`/api/v1`**, every route **except** `GET /api/v1/` (health) requires the
 
 Book **mutations** (`POST`, `PUT`, `PATCH`, and `DELETE` on `/api/v1/books` and `/api/v1/books/:id`) also require a valid user JWT in `Authorization: Bearer <token>` (obtain a token from `POST /api/v1/login`; the JWT string is at **`data.token`** in the JSON body). Book **reads** (`GET` list and `GET` by id) require the API key only.
 
+JWTs include a **`role`** claim (`user` or `admin`). New registrations get `user`. Protect admin routes with `middleware.RequireRole(auth.RoleAdmin)` after `JWTAuth` (see `GET /api/v1/admin/me`). Promote a user by setting `users.role` to `admin` in the database, then logging in again so the new role is embedded in the token.
+
 ```bash
 curl -H "X-API-Key: <YOUR_API_KEY>" http://localhost:8001/api/v1/books
 ```
@@ -229,6 +238,11 @@ curl -X POST \
   http://localhost:8001/api/v1/books
 ```
 
+```bash
+curl -H "X-API-Key: <YOUR_API_KEY>" \
+  -H "Authorization: Bearer <ADMIN_JWT>" \
+  http://localhost:8001/api/v1/admin/me
+```
 ## Contributing
 
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -52,6 +52,9 @@ const docTemplate = `{
                 "security": [
                     {
                         "ApiKeyAuth": []
+                    },
+                    {
+                        "JwtAuth": []
                     }
                 ],
                 "description": "Returns the authenticated admin's username, user id, and role from JWT claims. Example admin-only route for RBAC.",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -47,6 +47,43 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/me": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns the authenticated admin's username, user id, and role from JWT claims. Example admin-only route for RBAC.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Current admin identity",
+                "responses": {
+                    "200": {
+                        "description": "Admin identity in standard envelope",
+                        "schema": {
+                            "$ref": "#/definitions/models.AdminMeAPIResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/books": {
             "get": {
                 "security": [
@@ -527,6 +564,28 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "models.AdminMeAPIResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.AdminMeBody"
+                }
+            }
+        },
+        "models.AdminMeBody": {
+            "type": "object",
+            "properties": {
+                "role": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "integer"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
         "models.Book": {
             "type": "object",
             "properties": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -46,6 +46,9 @@
                 "security": [
                     {
                         "ApiKeyAuth": []
+                    },
+                    {
+                        "JwtAuth": []
                     }
                 ],
                 "description": "Returns the authenticated admin's username, user id, and role from JWT claims. Example admin-only route for RBAC.",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -41,6 +41,43 @@
                 }
             }
         },
+        "/admin/me": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns the authenticated admin's username, user id, and role from JWT claims. Example admin-only route for RBAC.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Current admin identity",
+                "responses": {
+                    "200": {
+                        "description": "Admin identity in standard envelope",
+                        "schema": {
+                            "$ref": "#/definitions/models.AdminMeAPIResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/books": {
             "get": {
                 "security": [
@@ -521,6 +558,28 @@
         }
     },
     "definitions": {
+        "models.AdminMeAPIResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.AdminMeBody"
+                }
+            }
+        },
+        "models.AdminMeBody": {
+            "type": "object",
+            "properties": {
+                "role": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "integer"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
         "models.Book": {
             "type": "object",
             "properties": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,5 +1,19 @@
 basePath: /api/v1
 definitions:
+  models.AdminMeAPIResponse:
+    properties:
+      data:
+        $ref: '#/definitions/models.AdminMeBody'
+    type: object
+  models.AdminMeBody:
+    properties:
+      role:
+        type: string
+      user_id:
+        type: integer
+      username:
+        type: string
+    type: object
   models.Book:
     properties:
       author:
@@ -110,6 +124,30 @@ paths:
       summary: ping example
       tags:
       - example
+  /admin/me:
+    get:
+      description: Returns the authenticated admin's username, user id, and role from
+        JWT claims. Example admin-only route for RBAC.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Admin identity in standard envelope
+          schema:
+            $ref: '#/definitions/models.AdminMeAPIResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "403":
+          description: Forbidden
+          schema:
+            type: string
+      security:
+      - ApiKeyAuth: []
+      summary: Current admin identity
+      tags:
+      - admin
   /books:
     get:
       description: Get a list of all books with optional pagination. List entries

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -145,6 +145,7 @@ paths:
             type: string
       security:
       - ApiKeyAuth: []
+      - JwtAuth: []
       summary: Current admin identity
       tags:
       - admin

--- a/pkg/api/admin_routes_test.go
+++ b/pkg/api/admin_routes_test.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"golang-rest-api-template/pkg/auth"
+	"golang-rest-api-template/pkg/middleware"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func testAdminRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	h := &userHandler{}
+	r := gin.New()
+	admin := r.Group("/admin", middleware.APIKeyAuth(), middleware.JWTAuth(), middleware.RequireRole(auth.RoleAdmin))
+	admin.GET("/me", h.AdminMeHandler)
+	return r
+}
+
+func TestAdminMeRequiresAdminRole(t *testing.T) {
+	r := testAdminRouter(t)
+
+	userTok, err := auth.GenerateToken("user", 1, auth.RoleUser)
+	assert.NoError(t, err)
+	adminTok, err := auth.GenerateToken("admin", 2, auth.RoleAdmin)
+	assert.NoError(t, err)
+
+	t.Run("user forbidden", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/admin/me", nil)
+		req.Header.Set("X-API-Key", testAPISecretKey)
+		req.Header.Set("Authorization", "Bearer "+userTok)
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
+
+	t.Run("admin ok", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/admin/me", nil)
+		req.Header.Set("X-API-Key", testAPISecretKey)
+		req.Header.Set("Authorization", "Bearer "+adminTok)
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		var body map[string]any
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+		data, _ := body["data"].(map[string]any)
+		assert.Equal(t, "admin", data["username"])
+		assert.Equal(t, auth.RoleAdmin, data["role"])
+		assert.EqualValues(t, 2, data["user_id"])
+	})
+}

--- a/pkg/api/book_routes_auth_test.go
+++ b/pkg/api/book_routes_auth_test.go
@@ -37,7 +37,7 @@ func testBookWriteMiddlewareStack(t *testing.T) *gin.Engine {
 func TestBookWriteRoutesRequireAPIKeyAndJWT(t *testing.T) {
 	const apiKey = testAPISecretKey
 
-	token, err := auth.GenerateToken("book-writer", 1)
+	token, err := auth.GenerateToken("book-writer", 1, auth.RoleUser)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -155,7 +155,7 @@ func TestBookWriteRoutesRequireAPIKeyAndJWT(t *testing.T) {
 func TestBookWriteRoutesRejectTamperedJWT(t *testing.T) {
 	const apiKey = testAPISecretKey
 
-	token, err := auth.GenerateToken("u1", 1)
+	token, err := auth.GenerateToken("u1", 1, auth.RoleUser)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -189,7 +189,7 @@ func TestBookWriteRoutesRejectTamperedJWT(t *testing.T) {
 func TestBookWriteRoutesConcurrentAuthorizedRequests(t *testing.T) {
 	const apiKey = testAPISecretKey
 
-	token, err := auth.GenerateToken("concurrent-user", 1)
+	token, err := auth.GenerateToken("concurrent-user", 1, auth.RoleUser)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"golang-rest-api-template/pkg/auth"
 	"golang-rest-api-template/pkg/cache"
 	"golang-rest-api-template/pkg/middleware"
 	"golang-rest-api-template/pkg/repository"
@@ -57,6 +58,11 @@ func NewRouter(logger *zap.Logger, mongoCollection *mongo.Collection, db *gorm.D
 
 		v1.POST("/login", middleware.APIKeyAuth(), users.LoginHandler)
 		v1.POST("/register", middleware.APIKeyAuth(), users.RegisterHandler)
+
+		admin := v1.Group("/admin", middleware.APIKeyAuth(), middleware.JWTAuth(), middleware.RequireRole(auth.RoleAdmin))
+		{
+			admin.GET("/me", users.AdminMeHandler)
+		}
 	}
 	r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))
 

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -107,6 +107,7 @@ func (h *userHandler) RegisterHandler(c *gin.Context) {
 // @Description Returns the authenticated admin's username, user id, and role from JWT claims. Example admin-only route for RBAC.
 // @Tags admin
 // @Security ApiKeyAuth
+// @Security JwtAuth
 // @Produce json
 // @Success 200 {object} models.AdminMeAPIResponse "Admin identity in standard envelope"
 // @Failure 401 {string} string "Unauthorized"

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -6,6 +6,7 @@ import (
 
 	"golang-rest-api-template/pkg/httperr"
 	"golang-rest-api-template/pkg/httpresp"
+	"golang-rest-api-template/pkg/middleware"
 	"golang-rest-api-template/pkg/models"
 	"golang-rest-api-template/pkg/repository"
 	"golang-rest-api-template/pkg/service"
@@ -17,6 +18,7 @@ import (
 type UserHandler interface {
 	LoginHandler(c *gin.Context)
 	RegisterHandler(c *gin.Context)
+	AdminMeHandler(c *gin.Context)
 }
 
 type userHandler struct {
@@ -97,4 +99,29 @@ func (h *userHandler) RegisterHandler(c *gin.Context) {
 		return
 	}
 	httpresp.Created(c, models.RegisterSuccessBody{Message: "Registration successful"})
+}
+
+// AdminMeHandler godoc
+// @Summary Current admin identity
+// @Schemes
+// @Description Returns the authenticated admin's username, user id, and role from JWT claims. Example admin-only route for RBAC.
+// @Tags admin
+// @Security ApiKeyAuth
+// @Produce json
+// @Success 200 {object} models.AdminMeAPIResponse "Admin identity in standard envelope"
+// @Failure 401 {string} string "Unauthorized"
+// @Failure 403 {string} string "Forbidden"
+// @Router /admin/me [get]
+func (h *userHandler) AdminMeHandler(c *gin.Context) {
+	username, _ := c.Get("username")
+	userID, _ := c.Get(middleware.ContextUserID)
+	role, _ := c.Get(middleware.ContextRole)
+	uid, _ := userID.(uint)
+	uname, _ := username.(string)
+	r, _ := role.(string)
+	httpresp.OK(c, models.AdminMeBody{
+		Username: uname,
+		UserID:   uid,
+		Role:     r,
+	})
 }

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -46,6 +46,8 @@ type Claims struct {
 	Username string `json:"username"`
 	// UserID is the authenticated users.id used for authorization (must be non-zero).
 	UserID uint `json:"user_id"`
+	// Role is the application role (e.g. RoleUser, RoleAdmin) used for RBAC.
+	Role string `json:"role"`
 	jwt.RegisteredClaims
 }
 
@@ -130,11 +132,15 @@ func bcryptCostForPasswordHashing() int {
 	return c
 }
 
-// GenerateToken issues an HS256 JWT with username and user_id claims. userID must
-// be non-zero (database primary key of the authenticated user).
-func GenerateToken(username string, userID uint) (string, error) {
+// GenerateToken issues an HS256 JWT with username, user_id, and role claims.
+// userID must be non-zero (database primary key of the authenticated user).
+// role must be a known application role (see ValidRole).
+func GenerateToken(username string, userID uint, role string) (string, error) {
 	if userID == 0 {
 		return "", fmt.Errorf("auth.GenerateToken: user id must be non-zero")
+	}
+	if !ValidRole(role) {
+		return "", fmt.Errorf("auth.GenerateToken: invalid role %q", role)
 	}
 	signingMu.RLock()
 	key := jwtSigningKey
@@ -147,6 +153,7 @@ func GenerateToken(username string, userID uint) (string, error) {
 	claims := &Claims{
 		Username: username,
 		UserID:   userID,
+		Role:     role,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(exp),
 		},

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -80,7 +80,7 @@ func TestHashPasswordInvalidBcryptCostEnvFallsBackToDefault(t *testing.T) {
 
 func TestGenerateToken(t *testing.T) {
 	user := "chud"
-	token, err := GenerateToken(user, 1)
+	token, err := GenerateToken(user, 1, RoleUser)
 	assert.Nil(t, err)
 	assert.NotEmpty(t, token)
 }
@@ -88,7 +88,7 @@ func TestGenerateToken(t *testing.T) {
 func TestGenerateTokenRoundTripUsernameClaim(t *testing.T) {
 	const wantUser = "alice"
 	const wantID uint = 42
-	tokenStr, err := GenerateToken(wantUser, wantID)
+	tokenStr, err := GenerateToken(wantUser, wantID, RoleUser)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -103,6 +103,28 @@ func TestGenerateTokenRoundTripUsernameClaim(t *testing.T) {
 	}
 	assert.Equal(t, wantUser, parsed.Username)
 	assert.Equal(t, wantID, parsed.UserID)
+	assert.Equal(t, RoleUser, parsed.Role)
+}
+
+func TestGenerateTokenRoundTripAdminRole(t *testing.T) {
+	tokenStr, err := GenerateToken("admin-user", 7, RoleAdmin)
+	if !assert.NoError(t, err) {
+		return
+	}
+	parsed := &Claims{}
+	token, err := jwt.ParseWithClaims(tokenStr, parsed, JWTKeyFunc(JWTSigningKey()))
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.True(t, token.Valid)
+	assert.Equal(t, RoleAdmin, parsed.Role)
+}
+
+func TestGenerateTokenRejectsInvalidRole(t *testing.T) {
+	_, err := GenerateToken("u", 1, "superuser")
+	assert.Error(t, err)
+	_, err = GenerateToken("u", 1, "")
+	assert.Error(t, err)
 }
 
 func TestGenerateRandomKey(t *testing.T) {
@@ -126,7 +148,7 @@ func TestSetJWTSigningKeyAcceptsMinimumLength(t *testing.T) {
 		return
 	}
 	assert.Equal(t, secret, JWTSigningKey())
-	_, err = GenerateToken("user-after-rotate", 1)
+	_, err = GenerateToken("user-after-rotate", 1, RoleUser)
 	assert.NoError(t, err)
 	// Restore default for other tests in the package.
 	assert.NoError(t, SetJWTSigningKey(bytes.Repeat([]byte("k"), MinJWTSecretKeyBytes)))
@@ -138,13 +160,13 @@ func TestGenerateTokenErrorWhenSigningKeyUnset(t *testing.T) {
 	t.Cleanup(func() {
 		assert.NoError(t, SetJWTSigningKey(prev))
 	})
-	_, err := GenerateToken("any", 1)
+	_, err := GenerateToken("any", 1, RoleUser)
 	assert.Error(t, err)
 	assert.True(t, errors.Is(err, ErrJWTSigningKeyNotConfigured))
 }
 
 func TestGenerateTokenRejectsZeroUserID(t *testing.T) {
-	_, err := GenerateToken("u", 0)
+	_, err := GenerateToken("u", 0, RoleUser)
 	assert.Error(t, err)
 }
 
@@ -154,6 +176,7 @@ func TestJWTKeyFuncRejectsNonHS256Algorithms(t *testing.T) {
 	baseClaims := Claims{
 		Username: "attacker",
 		UserID:   1,
+		Role:     RoleUser,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(exp),
 		},
@@ -189,6 +212,7 @@ func TestJWTKeyFuncAcceptsHS256(t *testing.T) {
 	claims := &Claims{
 		Username: "legit",
 		UserID:   9,
+		Role:     RoleAdmin,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
 		},

--- a/pkg/auth/roles.go
+++ b/pkg/auth/roles.go
@@ -1,0 +1,36 @@
+package auth
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Application roles embedded in JWTs and stored on users.role.
+const (
+	RoleUser  = "user"
+	RoleAdmin = "admin"
+)
+
+// ValidRole reports whether role is a known application role.
+func ValidRole(role string) bool {
+	switch role {
+	case RoleUser, RoleAdmin:
+		return true
+	default:
+		return false
+	}
+}
+
+// EffectiveRole returns a usable role for token issuance. An empty role
+// (for example rows created before the column existed) maps to RoleUser.
+// Unknown non-empty values are rejected.
+func EffectiveRole(role string) (string, error) {
+	r := strings.TrimSpace(role)
+	if r == "" {
+		return RoleUser, nil
+	}
+	if !ValidRole(r) {
+		return "", fmt.Errorf("invalid role %q", r)
+	}
+	return r, nil
+}

--- a/pkg/auth/roles_test.go
+++ b/pkg/auth/roles_test.go
@@ -1,0 +1,28 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidRole(t *testing.T) {
+	assert.True(t, ValidRole(RoleUser))
+	assert.True(t, ValidRole(RoleAdmin))
+	assert.False(t, ValidRole(""))
+	assert.False(t, ValidRole("superuser"))
+	assert.False(t, ValidRole("USER"))
+}
+
+func TestEffectiveRole(t *testing.T) {
+	got, err := EffectiveRole("")
+	assert.NoError(t, err)
+	assert.Equal(t, RoleUser, got)
+
+	got, err = EffectiveRole("  admin  ")
+	assert.NoError(t, err)
+	assert.Equal(t, RoleAdmin, got)
+
+	_, err = EffectiveRole("root")
+	assert.Error(t, err)
+}

--- a/pkg/middleware/jwt_auth.go
+++ b/pkg/middleware/jwt_auth.go
@@ -14,6 +14,10 @@ import (
 // (users.id), set by JWTAuth after successful verification.
 const ContextUserID = "user_id"
 
+// ContextRole is the Gin context key for the authenticated user's role claim,
+// set by JWTAuth after successful verification.
+const ContextRole = "role"
+
 // JWTAuth returns Gin middleware that requires a valid Bearer JWT signed
 // with HMAC-SHA256 using the application's JWT secret. Other algorithms are
 // rejected before signature verification.
@@ -57,8 +61,14 @@ func JWTAuth() gin.HandlerFunc {
 			return
 		}
 
+		if !auth.ValidRole(claims.Role) {
+			httperr.Abort(c, http.StatusUnauthorized, "Invalid token")
+			return
+		}
+
 		c.Set("username", claims.Username)
 		c.Set(ContextUserID, claims.UserID)
+		c.Set(ContextRole, claims.Role)
 		c.Next()
 	}
 }

--- a/pkg/middleware/jwt_auth_test.go
+++ b/pkg/middleware/jwt_auth_test.go
@@ -53,7 +53,7 @@ func TestJWTAuthSigningKeyNotConfiguredReturns503(t *testing.T) {
 }
 
 func TestJWTAuthValidBearer(t *testing.T) {
-	token, err := auth.GenerateToken("middleware-user", 1)
+	token, err := auth.GenerateToken("middleware-user", 1, auth.RoleUser)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -72,6 +72,7 @@ func TestJWTAuthRejectsZeroUserIDClaim(t *testing.T) {
 	claims := &auth.Claims{
 		Username: "legacy",
 		UserID:   0,
+		Role:     auth.RoleUser,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
 		},
@@ -93,7 +94,7 @@ func TestJWTAuthRejectsZeroUserIDClaim(t *testing.T) {
 
 func TestJWTAuthSetsUsernameContext(t *testing.T) {
 	const wantUser = "ctx-user"
-	token, err := auth.GenerateToken(wantUser, 99)
+	token, err := auth.GenerateToken(wantUser, 99, auth.RoleUser)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -124,7 +125,7 @@ func TestJWTAuthSetsUsernameContext(t *testing.T) {
 
 func TestJWTAuthSetsUserIDContext(t *testing.T) {
 	const wantID uint = 77
-	token, err := auth.GenerateToken("uid-ctx-user", wantID)
+	token, err := auth.GenerateToken("uid-ctx-user", wantID, auth.RoleUser)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -153,8 +154,63 @@ func TestJWTAuthSetsUserIDContext(t *testing.T) {
 	}
 }
 
+func TestJWTAuthSetsRoleContext(t *testing.T) {
+	token, err := auth.GenerateToken("role-ctx-user", 5, auth.RoleAdmin)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	var got string
+	r.GET("/p", JWTAuth(), func(c *gin.Context) {
+		v, ok := c.Get(ContextRole)
+		if !ok {
+			t.Error("role not in context")
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		got, _ = v.(string)
+		c.Status(http.StatusOK)
+	})
+	req := httptest.NewRequest(http.MethodGet, "/p", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d body=%q", rec.Code, rec.Body.String())
+	}
+	if got != auth.RoleAdmin {
+		t.Fatalf("role: got %q want %q", got, auth.RoleAdmin)
+	}
+}
+
+func TestJWTAuthRejectsMissingRoleClaim(t *testing.T) {
+	key := auth.JWTSigningKey()
+	claims := &auth.Claims{
+		Username: "no-role",
+		UserID:   1,
+		Role:     "",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	s, err := tok.SignedString(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := testRouterJWTAuthOnly(t)
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("Authorization", "Bearer "+s)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
 func TestJWTAuthRejectsBadRequests(t *testing.T) {
-	validHS256, err := auth.GenerateToken("ok-user", 1)
+	validHS256, err := auth.GenerateToken("ok-user", 1, auth.RoleUser)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -163,6 +219,7 @@ func TestJWTAuthRejectsBadRequests(t *testing.T) {
 	claims := &auth.Claims{
 		Username: "other",
 		UserID:   1,
+		Role:     auth.RoleUser,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(exp),
 		},
@@ -181,6 +238,7 @@ func TestJWTAuthRejectsBadRequests(t *testing.T) {
 	expiredClaims := &auth.Claims{
 		Username: "expired-user",
 		UserID:   1,
+		Role:     auth.RoleUser,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(-time.Hour)),
 		},
@@ -195,6 +253,7 @@ func TestJWTAuthRejectsBadRequests(t *testing.T) {
 	wrongSigClaims := &auth.Claims{
 		Username: "wrong-sig-user",
 		UserID:   1,
+		Role:     auth.RoleUser,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
 		},
@@ -286,7 +345,7 @@ func TestJWTAuthRejectsBadRequests(t *testing.T) {
 }
 
 func TestJWTAuthConcurrentValidRequests(t *testing.T) {
-	token, err := auth.GenerateToken("concurrent-jwt-user", 1)
+	token, err := auth.GenerateToken("concurrent-jwt-user", 1, auth.RoleUser)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}

--- a/pkg/middleware/rbac.go
+++ b/pkg/middleware/rbac.go
@@ -1,0 +1,35 @@
+package middleware
+
+import (
+	"net/http"
+
+	"golang-rest-api-template/pkg/httperr"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RequireRole returns Gin middleware that allows the request only when the
+// authenticated role (ContextRole, set by JWTAuth) matches one of allowed.
+// It must run after JWTAuth. Missing or disallowed roles yield 403 forbidden.
+func RequireRole(allowed ...string) gin.HandlerFunc {
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, r := range allowed {
+		if r == "" {
+			continue
+		}
+		allowedSet[r] = struct{}{}
+	}
+	return func(c *gin.Context) {
+		v, ok := c.Get(ContextRole)
+		if !ok {
+			httperr.Abort(c, http.StatusForbidden, "forbidden")
+			return
+		}
+		role, _ := v.(string)
+		if _, ok := allowedSet[role]; !ok {
+			httperr.Abort(c, http.StatusForbidden, "forbidden")
+			return
+		}
+		c.Next()
+	}
+}

--- a/pkg/middleware/rbac_test.go
+++ b/pkg/middleware/rbac_test.go
@@ -1,0 +1,111 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"golang-rest-api-template/pkg/auth"
+
+	"github.com/gin-gonic/gin"
+)
+
+func testRouterRequireRole(t *testing.T, allowed ...string) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/admin", JWTAuth(), RequireRole(allowed...), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	return r
+}
+
+func TestRequireRoleAllowsMatchingRole(t *testing.T) {
+	token, err := auth.GenerateToken("admin", 1, auth.RoleAdmin)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	r := testRouterRequireRole(t, auth.RoleAdmin)
+	req := httptest.NewRequest(http.MethodGet, "/admin", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRequireRoleForbidsDisallowedRole(t *testing.T) {
+	token, err := auth.GenerateToken("user", 2, auth.RoleUser)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	r := testRouterRequireRole(t, auth.RoleAdmin)
+	req := httptest.NewRequest(http.MethodGet, "/admin", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("json: %v raw=%q", err, rec.Body.String())
+	}
+	errVal, _ := body["error"].(string)
+	if !strings.Contains(errVal, "forbidden") {
+		t.Fatalf("error: got %q want substring forbidden", errVal)
+	}
+}
+
+func TestRequireRoleMissingContextForbids(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/admin", RequireRole(auth.RoleAdmin), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	req := httptest.NewRequest(http.MethodGet, "/admin", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRequireRoleTableDriven(t *testing.T) {
+	adminTok, err := auth.GenerateToken("a", 1, auth.RoleAdmin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	userTok, err := auth.GenerateToken("u", 2, auth.RoleUser)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		allowed    []string
+		token      string
+		wantStatus int
+	}{
+		{name: "admin allowed", allowed: []string{auth.RoleAdmin}, token: adminTok, wantStatus: http.StatusOK},
+		{name: "user on admin route", allowed: []string{auth.RoleAdmin}, token: userTok, wantStatus: http.StatusForbidden},
+		{name: "either role admin", allowed: []string{auth.RoleUser, auth.RoleAdmin}, token: adminTok, wantStatus: http.StatusOK},
+		{name: "either role user", allowed: []string{auth.RoleUser, auth.RoleAdmin}, token: userTok, wantStatus: http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := testRouterRequireRole(t, tt.allowed...)
+			req := httptest.NewRequest(http.MethodGet, "/admin", nil)
+			req.Header.Set("Authorization", "Bearer "+tt.token)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status: got %d want %d body=%q", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+		})
+	}
+}

--- a/pkg/models/api_json.go
+++ b/pkg/models/api_json.go
@@ -14,3 +14,8 @@ type LoginAPIResponse struct {
 type RegisterAPIResponse struct {
 	Data RegisterSuccessBody `json:"data"`
 }
+
+// AdminMeAPIResponse documents GET /admin/me 200 JSON.
+type AdminMeAPIResponse struct {
+	Data AdminMeBody `json:"data"`
+}

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -17,10 +17,18 @@ type RegisterSuccessBody struct {
 	Message string `json:"message"`
 }
 
+// AdminMeBody is the "data" object returned by GET /admin/me on success.
+type AdminMeBody struct {
+	Username string `json:"username"`
+	UserID   uint   `json:"user_id"`
+	Role     string `json:"role"`
+}
+
 type User struct {
 	ID        uint      `json:"id" gorm:"primary_key"`
 	Username  string    `json:"username" gorm:"unique"`
 	Password  string    `json:"-"`
+	Role      string    `json:"role" gorm:"type:varchar(32);not null;default:'user'"`
 	CreatedAt time.Time `json:"created_at" gorm:"autoCreateTime"`
 	UpdatedAt time.Time `json:"updated_at" gorm:"autoUpdateTime"`
 }

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -11,6 +11,7 @@ func TestUserJSONOmitsPassword(t *testing.T) {
 		ID:        1,
 		Username:  "alice",
 		Password:  "bcrypt-digest-must-not-leak",
+		Role:      "user",
 		CreatedAt: time.Unix(1000, 0).UTC(),
 		UpdatedAt: time.Unix(2000, 0).UTC(),
 	}
@@ -27,5 +28,8 @@ func TestUserJSONOmitsPassword(t *testing.T) {
 	}
 	if m["username"] != "alice" {
 		t.Fatalf("username: got %v", m["username"])
+	}
+	if m["role"] != "user" {
+		t.Fatalf("role: got %v", m["role"])
 	}
 }

--- a/pkg/service/user_service.go
+++ b/pkg/service/user_service.go
@@ -44,7 +44,11 @@ func (s *UserService) Login(_ context.Context, username, password string) (token
 	if err := bcrypt.CompareHashAndPassword([]byte(dbUser.Password), []byte(password)); err != nil {
 		return "", ErrInvalidLogin
 	}
-	tok, err := auth.GenerateToken(dbUser.Username, dbUser.ID)
+	role, err := auth.EffectiveRole(dbUser.Role)
+	if err != nil {
+		return "", fmtError(ErrTokenGenerate, err)
+	}
+	tok, err := auth.GenerateToken(dbUser.Username, dbUser.ID, role)
 	if err != nil {
 		return "", fmtError(ErrTokenGenerate, err)
 	}
@@ -57,7 +61,7 @@ func (s *UserService) Register(_ context.Context, username, password string) err
 	if err != nil {
 		return fmtError(ErrRegisterHash, err)
 	}
-	newUser := &models.User{Username: username, Password: hashedPassword}
+	newUser := &models.User{Username: username, Password: hashedPassword, Role: auth.RoleUser}
 	if err := s.users.Create(newUser); err != nil {
 		if errors.Is(err, repository.ErrUserUsernameConflict) {
 			return ErrRegisterConflict

--- a/pkg/service/user_service_test.go
+++ b/pkg/service/user_service_test.go
@@ -11,6 +11,7 @@ import (
 	"golang-rest-api-template/pkg/models"
 	"golang-rest-api-template/pkg/repository"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
@@ -81,13 +82,74 @@ func TestUserServiceLoginSuccess(t *testing.T) {
 	assert.NoError(t, err)
 	store := &fakeUserStore{
 		findFn: func(username string) (*models.User, error) {
-			return &models.User{ID: 100, Username: "alice", Password: string(hash)}, nil
+			return &models.User{ID: 100, Username: "alice", Password: string(hash), Role: auth.RoleUser}, nil
 		},
 	}
 	svc := NewUserService(store)
 	tok, err := svc.Login(context.Background(), "alice", "secret")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, tok)
+}
+
+func TestUserServiceLoginEmbedsAdminRole(t *testing.T) {
+	prev := auth.JWTSigningKey()
+	t.Cleanup(func() { _ = auth.SetJWTSigningKey(prev) })
+	assert.NoError(t, auth.SetJWTSigningKey(bytes.Repeat([]byte("s"), auth.MinJWTSecretKeyBytes)))
+
+	hash, err := bcrypt.GenerateFromPassword([]byte("secret"), bcrypt.MinCost)
+	assert.NoError(t, err)
+	store := &fakeUserStore{
+		findFn: func(username string) (*models.User, error) {
+			return &models.User{ID: 3, Username: "boss", Password: string(hash), Role: auth.RoleAdmin}, nil
+		},
+	}
+	svc := NewUserService(store)
+	tok, err := svc.Login(context.Background(), "boss", "secret")
+	assert.NoError(t, err)
+
+	parsed := &auth.Claims{}
+	token, err := jwt.ParseWithClaims(tok, parsed, auth.JWTKeyFunc(auth.JWTSigningKey()))
+	assert.NoError(t, err)
+	assert.True(t, token.Valid)
+	assert.Equal(t, auth.RoleAdmin, parsed.Role)
+}
+
+func TestUserServiceLoginEmptyRoleDefaultsToUser(t *testing.T) {
+	prev := auth.JWTSigningKey()
+	t.Cleanup(func() { _ = auth.SetJWTSigningKey(prev) })
+	assert.NoError(t, auth.SetJWTSigningKey(bytes.Repeat([]byte("s"), auth.MinJWTSecretKeyBytes)))
+
+	hash, err := bcrypt.GenerateFromPassword([]byte("secret"), bcrypt.MinCost)
+	assert.NoError(t, err)
+	store := &fakeUserStore{
+		findFn: func(username string) (*models.User, error) {
+			return &models.User{ID: 4, Username: "legacy", Password: string(hash), Role: ""}, nil
+		},
+	}
+	svc := NewUserService(store)
+	tok, err := svc.Login(context.Background(), "legacy", "secret")
+	assert.NoError(t, err)
+
+	parsed := &auth.Claims{}
+	_, err = jwt.ParseWithClaims(tok, parsed, auth.JWTKeyFunc(auth.JWTSigningKey()))
+	assert.NoError(t, err)
+	assert.Equal(t, auth.RoleUser, parsed.Role)
+}
+
+func TestUserServiceRegisterSetsUserRole(t *testing.T) {
+	var created *models.User
+	store := &fakeUserStore{
+		createFn: func(user *models.User) error {
+			created = user
+			return nil
+		},
+	}
+	svc := NewUserService(store)
+	err := svc.Register(context.Background(), "newbie", "password123")
+	assert.NoError(t, err)
+	if assert.NotNil(t, created) {
+		assert.Equal(t, auth.RoleUser, created.Role)
+	}
 }
 
 func TestUserServiceRegisterConflictDuplicatedKey(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds role-based access control as a foundation for admin-only routes ([#141](https://github.com/LAA-Software-Engineering/golang-rest-api-template/issues/141)):

- Persist `users.role` (`user` / `admin`; default `user` on register)
- Embed `role` in JWT claims at login
- Expose `middleware.RequireRole` (after `JWTAuth`) and demo route `GET /api/v1/admin/me`

## Type of change

- [x] New feature

## How to test

```bash
go test ./pkg/... -count=1
```

Promote a user with `UPDATE users SET role = 'admin' WHERE username = '...';`, log in again, then:

```bash
curl -H "X-API-Key: <KEY>" -H "Authorization: Bearer <ADMIN_JWT>" http://localhost:8001/api/v1/admin/me
```

## Checklist

- [x] `go test ./pkg/...` passes locally
- [x] Swagger regenerated (`docs/` updated)
- [x] README updated for RBAC / admin route
- [x] No new secrets committed

## Related issues

Closes #141

Made with [Cursor](https://cursor.com)