### PR TITLE
feat(auth): refresh tokens and optional Redis JWT denylist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,14 @@ MONGODB_URI=mongodb://localhost:27017
 # Generate with: go run ./scripts/generate_key.go
 JWT_SECRET_KEY=replace-me-generate-with-scripts-generate-key
 
+# Optional: access JWT lifetime (Go duration). Default 5m.
+# ACCESS_TOKEN_TTL=5m
+# Optional: opaque refresh token lifetime. Default 168h (7 days).
+# REFRESH_TOKEN_TTL=168h
+# Optional Redis jti denylist for logout (default true). Set false to skip Redis checks;
+# login/refresh/logout still work via Postgres refresh tokens.
+# TOKEN_DENYLIST_ENABLED=true
+
 # Optional: bcrypt cost for new password hashes (10–31; default 12). Omit for default.
 # BCRYPT_COST=12
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
           cache: true
       - name: Verify go.mod tidy
         run: |
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
           cache: true
       - name: Govulncheck
         run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
           cache: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
@@ -67,7 +67,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
           cache: true
 
       - name: Build
@@ -82,7 +82,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
           cache: true
 
       - name: Unit tests with coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Align with go.mod and CI.
-FROM golang:1.25.12-bookworm AS builder
+FROM golang:1.25.13-bookworm AS builder
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ golang-rest-api-template/
 
 ### Prerequisites
 
-- Go 1.25.12 or newer (see `go.mod`; aligns CI and Docker with `govulncheck` / patched stdlib)
+- Go 1.25.13 or newer (see `go.mod`; aligns CI and Docker with `govulncheck` / patched stdlib)
 - Docker
 - Docker Compose
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,9 @@ Names below match `os.Getenv` usage in this repository:
 | `REDIS_READ_TIMEOUT` | Read timeout (default `3s`) |
 | `REDIS_WRITE_TIMEOUT` | Write timeout (default `3s`) |
 | `JWT_SECRET_KEY` | Secret for signing JWTs (`pkg/auth/auth.go`) |
+| `ACCESS_TOKEN_TTL` | Optional access JWT lifetime (Go duration; default `5m`) |
+| `REFRESH_TOKEN_TTL` | Optional opaque refresh token lifetime (Go duration; default `168h` / 7 days) |
+| `TOKEN_DENYLIST_ENABLED` | Optional Redis `jti` denylist for logout (`true`/`false`; default on). When off or Redis is unavailable, login/refresh/logout still work via Postgres; access JWTs remain valid until natural expiry after logout. |
 | `BCRYPT_COST` | Optional bcrypt work factor for **new** password hashes (integer `10`–`31`; default **`12`**, was 14). Values below `10` clamp to `10` with a log line. See [#128](https://github.com/LAA-Software-Engineering/golang-rest-api-template/issues/128). |
 | `API_SECRET_KEY` | Secret compared to the `X-API-Key` header (`pkg/middleware/api_key.go`) |
 | `GIN_MODE` | Standard Gin variable: `debug` (default if unset), `release` (enables Security + XSS middleware in `pkg/api/router.go`), or `test` |
@@ -230,14 +233,16 @@ http://localhost:8001/swagger/index.html
 - `PUT /api/v1/books/:id`: Replace a book's title and author (both fields required in the JSON body).
 - `PATCH /api/v1/books/:id`: Partially update a book (send only the fields to change; at least one of `title` or `author` is required).
 - `DELETE /api/v1/books/:id`: Delete a book.
-- `POST /api/v1/login`: Login.
+- `POST /api/v1/login`: Login (returns access JWT + opaque refresh token).
+- `POST /api/v1/refresh`: Rotate refresh token and issue a new access JWT.
+- `POST /api/v1/logout`: Revoke refresh token(s); denylist access JWT `jti` when Redis denylist is enabled.
 - `POST /api/v1/register`: Register a new user.
 - `GET /api/v1/admin/me`: Admin-only identity probe (API key + JWT with `role=admin`).
 - `GET /swagger/*`: Swagger UI (no `X-API-Key`).
 
 ### JSON responses
 
-Successful `/api/v1` JSON responses use a single envelope: **`{"data": ...}`** (implemented in `pkg/httpresp`). Examples: `GET /api/v1/` returns `{"data":"ok"}`; book list and book CRUD return the resource or collection inside `data`; `POST /api/v1/login` returns `{"data":{"token":"<jwt>"}}`; `POST /api/v1/register` returns `{"data":{"message":"Registration successful"}}`.
+Successful `/api/v1` JSON responses use a single envelope: **`{"data": ...}`** (implemented in `pkg/httpresp`). Examples: `GET /api/v1/` returns `{"data":"ok"}`; book list and book CRUD return the resource or collection inside `data`; `POST /api/v1/login` returns `{"data":{"token":"<jwt>","access_token":"<jwt>","refresh_token":"...","expires_in":300}}` (`token` aliases `access_token` for older clients); `POST /api/v1/register` returns `{"data":{"message":"Registration successful"}}`.
 
 Error responses use **`{"error":"..."}`** (`pkg/httperr`). RFC 7807-style problem details are not used yet.
 
@@ -245,7 +250,9 @@ Error responses use **`{"error":"..."}`** (`pkg/httperr`). RFC 7807-style proble
 
 Under **`/api/v1`**, every route **except** `GET /api/v1/` (health) requires the **`X-API-Key`** header matching **`API_SECRET_KEY`** (service-to-service gate).
 
-Book **mutations** (`POST`, `PUT`, `PATCH`, and `DELETE` on `/api/v1/books` and `/api/v1/books/:id`) also require a valid user JWT in `Authorization: Bearer <token>` (obtain a token from `POST /api/v1/login`; the JWT string is at **`data.token`** in the JSON body). Book **reads** (`GET` list and `GET` by id) require the API key only.
+Book **mutations** (`POST`, `PUT`, `PATCH`, and `DELETE` on `/api/v1/books` and `/api/v1/books/:id`) also require a valid user JWT in `Authorization: Bearer <token>` (obtain tokens from `POST /api/v1/login`; the access JWT is at **`data.access_token`** or legacy **`data.token`**). Book **reads** (`GET` list and `GET` by id) require the API key only.
+
+Access JWTs are short-lived (default 5 minutes, configurable via `ACCESS_TOKEN_TTL`) and include `jti` / `iat`. Use `POST /api/v1/refresh` with `{"refresh_token":"..."}` to rotate the opaque refresh token (stored hashed in Postgres) and obtain a new pair. Reuse of a consumed refresh token revokes that token family. `POST /api/v1/logout` (API key + Bearer access JWT) revokes refresh tokens; when `TOKEN_DENYLIST_ENABLED` is on and Redis is reachable, the access JWT `jti` is denylisted until expiry.
 
 JWTs include a **`role`** claim (`user` or `admin`). New registrations get `user`. Protect admin routes with `middleware.RequireRole(auth.RoleAdmin)` after `JWTAuth` (see `GET /api/v1/admin/me`). Promote a user by setting `users.role` to `admin` in the database, then logging in again so the new role is embedded in the token.
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -21,7 +21,7 @@ import (
 
 // @title           golang-rest-api-template
 // @version         1.0
-// @description     Go/Gin REST API template: books CRUD, register/login, Redis-backed list cache, Postgres via GORM, Mongo access logs, rate limiting, and Swagger.
+// @description     Go/Gin REST API template: books CRUD, register/login/refresh/logout, Redis-backed list cache and optional JWT denylist, Postgres via GORM, Mongo access logs, rate limiting, and Swagger.
 // @termsOfService  http://swagger.io/terms/
 
 // @contact.name   API Support

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -458,7 +458,7 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Authenticates a user using username and password, returns a JWT token if successful",
+                "description": "Authenticates a user using username and password; returns access JWT and opaque refresh token",
                 "consumes": [
                     "application/json"
                 ],
@@ -482,9 +482,119 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "JWT in standard envelope",
+                        "description": "Tokens in standard envelope",
                         "schema": {
                             "$ref": "#/definitions/models.LoginAPIResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/logout": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "JwtAuth": []
+                    }
+                ],
+                "description": "Revokes refresh token(s) for the authenticated user and denylists the current access JWT when Redis denylist is enabled",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "user"
+                ],
+                "summary": "Log out and revoke tokens",
+                "parameters": [
+                    {
+                        "description": "Optional refresh token to revoke a single family",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/models.LogoutRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Logout confirmation",
+                        "schema": {
+                            "$ref": "#/definitions/models.LogoutAPIResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/refresh": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Exchanges a valid refresh token for a new access JWT and rotated refresh token",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "user"
+                ],
+                "summary": "Refresh access token",
+                "parameters": [
+                    {
+                        "description": "Refresh token",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.RefreshRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "New tokens in standard envelope",
+                        "schema": {
+                            "$ref": "#/definitions/models.RefreshAPIResponse"
                         }
                     },
                     "400": {
@@ -646,6 +756,15 @@ const docTemplate = `{
         "models.LoginTokenBody": {
             "type": "object",
             "properties": {
+                "access_token": {
+                    "type": "string"
+                },
+                "expires_in": {
+                    "type": "integer"
+                },
+                "refresh_token": {
+                    "type": "string"
+                },
                 "token": {
                     "type": "string"
                 }
@@ -666,6 +785,30 @@ const docTemplate = `{
                 }
             }
         },
+        "models.LogoutAPIResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.LogoutSuccessBody"
+                }
+            }
+        },
+        "models.LogoutRequest": {
+            "type": "object",
+            "properties": {
+                "refresh_token": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.LogoutSuccessBody": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
         "models.PatchBook": {
             "type": "object",
             "properties": {
@@ -673,6 +816,25 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.RefreshAPIResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.LoginTokenBody"
+                }
+            }
+        },
+        "models.RefreshRequest": {
+            "type": "object",
+            "required": [
+                "refresh_token"
+            ],
+            "properties": {
+                "refresh_token": {
                     "type": "string"
                 }
             }
@@ -734,7 +896,7 @@ var SwaggerInfo = &swag.Spec{
 	BasePath:         "/api/v1",
 	Schemes:          []string{},
 	Title:            "golang-rest-api-template",
-	Description:      "Go/Gin REST API template: books CRUD, register/login, Redis-backed list cache, Postgres via GORM, Mongo access logs, rate limiting, and Swagger.",
+	Description:      "Go/Gin REST API template: books CRUD, register/login/refresh/logout, Redis-backed list cache and optional JWT denylist, Postgres via GORM, Mongo access logs, rate limiting, and Swagger.",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
 	LeftDelim:        "{{",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1,7 +1,7 @@
 {
     "swagger": "2.0",
     "info": {
-        "description": "Go/Gin REST API template: books CRUD, register/login, Redis-backed list cache, Postgres via GORM, Mongo access logs, rate limiting, and Swagger.",
+        "description": "Go/Gin REST API template: books CRUD, register/login/refresh/logout, Redis-backed list cache and optional JWT denylist, Postgres via GORM, Mongo access logs, rate limiting, and Swagger.",
         "title": "golang-rest-api-template",
         "termsOfService": "http://swagger.io/terms/",
         "contact": {
@@ -452,7 +452,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Authenticates a user using username and password, returns a JWT token if successful",
+                "description": "Authenticates a user using username and password; returns access JWT and opaque refresh token",
                 "consumes": [
                     "application/json"
                 ],
@@ -476,9 +476,119 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "JWT in standard envelope",
+                        "description": "Tokens in standard envelope",
                         "schema": {
                             "$ref": "#/definitions/models.LoginAPIResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/logout": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "JwtAuth": []
+                    }
+                ],
+                "description": "Revokes refresh token(s) for the authenticated user and denylists the current access JWT when Redis denylist is enabled",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "user"
+                ],
+                "summary": "Log out and revoke tokens",
+                "parameters": [
+                    {
+                        "description": "Optional refresh token to revoke a single family",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/models.LogoutRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Logout confirmation",
+                        "schema": {
+                            "$ref": "#/definitions/models.LogoutAPIResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/refresh": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Exchanges a valid refresh token for a new access JWT and rotated refresh token",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "user"
+                ],
+                "summary": "Refresh access token",
+                "parameters": [
+                    {
+                        "description": "Refresh token",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.RefreshRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "New tokens in standard envelope",
+                        "schema": {
+                            "$ref": "#/definitions/models.RefreshAPIResponse"
                         }
                     },
                     "400": {
@@ -640,6 +750,15 @@
         "models.LoginTokenBody": {
             "type": "object",
             "properties": {
+                "access_token": {
+                    "type": "string"
+                },
+                "expires_in": {
+                    "type": "integer"
+                },
+                "refresh_token": {
+                    "type": "string"
+                },
                 "token": {
                     "type": "string"
                 }
@@ -660,6 +779,30 @@
                 }
             }
         },
+        "models.LogoutAPIResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.LogoutSuccessBody"
+                }
+            }
+        },
+        "models.LogoutRequest": {
+            "type": "object",
+            "properties": {
+                "refresh_token": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.LogoutSuccessBody": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
         "models.PatchBook": {
             "type": "object",
             "properties": {
@@ -667,6 +810,25 @@
                     "type": "string"
                 },
                 "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.RefreshAPIResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.LoginTokenBody"
+                }
+            }
+        },
+        "models.RefreshRequest": {
+            "type": "object",
+            "required": [
+                "refresh_token"
+            ],
+            "properties": {
+                "refresh_token": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -51,6 +51,12 @@ definitions:
     type: object
   models.LoginTokenBody:
     properties:
+      access_token:
+        type: string
+      expires_in:
+        type: integer
+      refresh_token:
+        type: string
       token:
         type: string
     type: object
@@ -64,12 +70,39 @@ definitions:
     - password
     - username
     type: object
+  models.LogoutAPIResponse:
+    properties:
+      data:
+        $ref: '#/definitions/models.LogoutSuccessBody'
+    type: object
+  models.LogoutRequest:
+    properties:
+      refresh_token:
+        type: string
+    type: object
+  models.LogoutSuccessBody:
+    properties:
+      message:
+        type: string
+    type: object
   models.PatchBook:
     properties:
       author:
         type: string
       title:
         type: string
+    type: object
+  models.RefreshAPIResponse:
+    properties:
+      data:
+        $ref: '#/definitions/models.LoginTokenBody'
+    type: object
+  models.RefreshRequest:
+    properties:
+      refresh_token:
+        type: string
+    required:
+    - refresh_token
     type: object
   models.RegisterAPIResponse:
     properties:
@@ -100,8 +133,9 @@ info:
     email: support@swagger.io
     name: API Support
     url: http://www.swagger.io/support
-  description: 'Go/Gin REST API template: books CRUD, register/login, Redis-backed
-    list cache, Postgres via GORM, Mongo access logs, rate limiting, and Swagger.'
+  description: 'Go/Gin REST API template: books CRUD, register/login/refresh/logout,
+    Redis-backed list cache and optional JWT denylist, Postgres via GORM, Mongo access
+    logs, rate limiting, and Swagger.'
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
@@ -389,8 +423,8 @@ paths:
     post:
       consumes:
       - application/json
-      description: Authenticates a user using username and password, returns a JWT
-        token if successful
+      description: Authenticates a user using username and password; returns access
+        JWT and opaque refresh token
       parameters:
       - description: User login object
         in: body
@@ -402,7 +436,7 @@ paths:
       - application/json
       responses:
         "200":
-          description: JWT in standard envelope
+          description: Tokens in standard envelope
           schema:
             $ref: '#/definitions/models.LoginAPIResponse'
         "400":
@@ -420,6 +454,76 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Authenticate a user
+      tags:
+      - user
+  /logout:
+    post:
+      consumes:
+      - application/json
+      description: Revokes refresh token(s) for the authenticated user and denylists
+        the current access JWT when Redis denylist is enabled
+      parameters:
+      - description: Optional refresh token to revoke a single family
+        in: body
+        name: body
+        schema:
+          $ref: '#/definitions/models.LogoutRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Logout confirmation
+          schema:
+            $ref: '#/definitions/models.LogoutAPIResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      security:
+      - ApiKeyAuth: []
+      - JwtAuth: []
+      summary: Log out and revoke tokens
+      tags:
+      - user
+  /refresh:
+    post:
+      consumes:
+      - application/json
+      description: Exchanges a valid refresh token for a new access JWT and rotated
+        refresh token
+      parameters:
+      - description: Refresh token
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/models.RefreshRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: New tokens in standard envelope
+          schema:
+            $ref: '#/definitions/models.RefreshAPIResponse'
+        "400":
+          description: Bad Request
+          schema:
+            type: string
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      security:
+      - ApiKeyAuth: []
+      summary: Refresh access token
       tags:
       - user
   /register:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module golang-rest-api-template
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/araujo88/gin-gonic-xss-middleware v0.0.0-20221014023455-d89f16de6a7e

--- a/pkg/api/admin_routes_test.go
+++ b/pkg/api/admin_routes_test.go
@@ -18,7 +18,7 @@ func testAdminRouter(t *testing.T) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	h := &userHandler{}
 	r := gin.New()
-	admin := r.Group("/admin", middleware.APIKeyAuth(), middleware.JWTAuth(), middleware.RequireRole(auth.RoleAdmin))
+	admin := r.Group("/admin", middleware.APIKeyAuth(), middleware.JWTAuth(auth.NoopDenylist{}), middleware.RequireRole(auth.RoleAdmin))
 	admin.GET("/me", h.AdminMeHandler)
 	return r
 }

--- a/pkg/api/book_routes_auth_test.go
+++ b/pkg/api/book_routes_auth_test.go
@@ -28,9 +28,9 @@ func testBookWriteMiddlewareStack(t *testing.T) *gin.Engine {
 			c.Status(http.StatusOK)
 		}
 	}
-	r.PUT("/api/v1/books/:id", middleware.APIKeyAuth(), middleware.JWTAuth(), ok)
-	r.PATCH("/api/v1/books/:id", middleware.APIKeyAuth(), middleware.JWTAuth(), ok)
-	r.DELETE("/api/v1/books/:id", middleware.APIKeyAuth(), middleware.JWTAuth(), ok)
+	r.PUT("/api/v1/books/:id", middleware.APIKeyAuth(), middleware.JWTAuth(auth.NoopDenylist{}), ok)
+	r.PATCH("/api/v1/books/:id", middleware.APIKeyAuth(), middleware.JWTAuth(auth.NoopDenylist{}), ok)
+	r.DELETE("/api/v1/books/:id", middleware.APIKeyAuth(), middleware.JWTAuth(auth.NoopDenylist{}), ok)
 	return r
 }
 

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -22,8 +22,15 @@ import (
 
 // NewRouter builds the Gin engine with middleware, Swagger, and API routes.
 func NewRouter(logger *zap.Logger, mongoCollection *mongo.Collection, db *gorm.DB, redisClient cache.Cache) *gin.Engine {
+	denylist := auth.NewTokenDenylistFromEnv(redisClient)
+	jwtAuth := middleware.JWTAuth(denylist)
+
 	books := NewBookHandler(repository.NewGormBookStore(db), redisClient)
-	users := NewUserHandler(repository.NewGormUserStore(db))
+	users := NewUserHandler(
+		repository.NewGormUserStore(db),
+		repository.NewGormRefreshTokenStore(db),
+		denylist,
+	)
 
 	r := gin.Default()
 	if err := configureTrustedProxies(r); err != nil {
@@ -56,16 +63,18 @@ func NewRouter(logger *zap.Logger, mongoCollection *mongo.Collection, db *gorm.D
 	{
 		v1.GET("/", books.Healthcheck)
 		v1.GET("/books", middleware.APIKeyAuth(), books.FindBooks)
-		v1.POST("/books", middleware.APIKeyAuth(), middleware.JWTAuth(), books.CreateBook)
+		v1.POST("/books", middleware.APIKeyAuth(), jwtAuth, books.CreateBook)
 		v1.GET("/books/:id", middleware.APIKeyAuth(), books.FindBook)
-		v1.PUT("/books/:id", middleware.APIKeyAuth(), middleware.JWTAuth(), books.UpdateBook)
-		v1.PATCH("/books/:id", middleware.APIKeyAuth(), middleware.JWTAuth(), books.PatchBook)
-		v1.DELETE("/books/:id", middleware.APIKeyAuth(), middleware.JWTAuth(), books.DeleteBook)
+		v1.PUT("/books/:id", middleware.APIKeyAuth(), jwtAuth, books.UpdateBook)
+		v1.PATCH("/books/:id", middleware.APIKeyAuth(), jwtAuth, books.PatchBook)
+		v1.DELETE("/books/:id", middleware.APIKeyAuth(), jwtAuth, books.DeleteBook)
 
 		v1.POST("/login", middleware.APIKeyAuth(), users.LoginHandler)
 		v1.POST("/register", middleware.APIKeyAuth(), users.RegisterHandler)
+		v1.POST("/refresh", middleware.APIKeyAuth(), users.RefreshHandler)
+		v1.POST("/logout", middleware.APIKeyAuth(), jwtAuth, users.LogoutHandler)
 
-		admin := v1.Group("/admin", middleware.APIKeyAuth(), middleware.JWTAuth(), middleware.RequireRole(auth.RoleAdmin))
+		admin := v1.Group("/admin", middleware.APIKeyAuth(), jwtAuth, middleware.RequireRole(auth.RoleAdmin))
 		{
 			admin.GET("/me", users.AdminMeHandler)
 		}

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -3,7 +3,9 @@ package api
 import (
 	"errors"
 	"net/http"
+	"time"
 
+	"golang-rest-api-template/pkg/auth"
 	"golang-rest-api-template/pkg/httperr"
 	"golang-rest-api-template/pkg/httpresp"
 	"golang-rest-api-template/pkg/middleware"
@@ -18,6 +20,8 @@ import (
 type UserHandler interface {
 	LoginHandler(c *gin.Context)
 	RegisterHandler(c *gin.Context)
+	RefreshHandler(c *gin.Context)
+	LogoutHandler(c *gin.Context)
 	AdminMeHandler(c *gin.Context)
 }
 
@@ -25,9 +29,18 @@ type userHandler struct {
 	svc *service.UserService
 }
 
-// NewUserHandler wires persistence into user HTTP handlers.
-func NewUserHandler(store repository.UserPersistence) *userHandler {
-	return &userHandler{svc: service.NewUserService(store)}
+// NewUserHandler wires persistence and denylist into user HTTP handlers.
+func NewUserHandler(users repository.UserPersistence, refresh repository.RefreshTokenPersistence, denylist auth.TokenDenylist) *userHandler {
+	return &userHandler{svc: service.NewUserService(users, refresh, denylist)}
+}
+
+func tokenPairBody(p service.TokenPair) models.LoginTokenBody {
+	return models.LoginTokenBody{
+		Token:        p.AccessToken,
+		AccessToken:  p.AccessToken,
+		RefreshToken: p.RefreshToken,
+		ExpiresIn:    p.ExpiresIn,
+	}
 }
 
 // @BasePath /api/v1
@@ -35,13 +48,13 @@ func NewUserHandler(store repository.UserPersistence) *userHandler {
 // LoginHandler godoc
 // @Summary Authenticate a user
 // @Schemes
-// @Description Authenticates a user using username and password, returns a JWT token if successful
+// @Description Authenticates a user using username and password; returns access JWT and opaque refresh token
 // @Tags user
 // @Security ApiKeyAuth
 // @Accept  json
 // @Produce  json
 // @Param   user     body    models.LoginUser     true        "User login object"
-// @Success 200 {object} models.LoginAPIResponse "JWT in standard envelope"
+// @Success 200 {object} models.LoginAPIResponse "Tokens in standard envelope"
 // @Failure 400 {string} string "Bad Request"
 // @Failure 401 {string} string "Unauthorized"
 // @Failure 500 {string} string "Internal Server Error"
@@ -52,19 +65,92 @@ func (h *userHandler) LoginHandler(c *gin.Context) {
 		httperr.Write(c, http.StatusBadRequest, err.Error())
 		return
 	}
-	token, err := h.svc.Login(c.Request.Context(), incoming.Username, incoming.Password)
+	pair, err := h.svc.Login(c.Request.Context(), incoming.Username, incoming.Password)
 	if err != nil {
 		switch {
 		case errors.Is(err, service.ErrInvalidLogin):
 			httperr.Write(c, http.StatusUnauthorized, "Invalid username or password")
-		case errors.Is(err, service.ErrLoginDB), errors.Is(err, service.ErrTokenGenerate):
+		case errors.Is(err, service.ErrLoginDB), errors.Is(err, service.ErrTokenGenerate), errors.Is(err, service.ErrRefreshPersist):
 			httperr.Write(c, http.StatusInternalServerError, "Internal Server Error")
 		default:
 			httperr.Write(c, http.StatusInternalServerError, "Internal Server Error")
 		}
 		return
 	}
-	httpresp.OK(c, models.LoginTokenBody{Token: token})
+	httpresp.OK(c, tokenPairBody(pair))
+}
+
+// RefreshHandler godoc
+// @Summary Refresh access token
+// @Schemes
+// @Description Exchanges a valid refresh token for a new access JWT and rotated refresh token
+// @Tags user
+// @Security ApiKeyAuth
+// @Accept  json
+// @Produce  json
+// @Param   body  body  models.RefreshRequest  true  "Refresh token"
+// @Success 200 {object} models.RefreshAPIResponse "New tokens in standard envelope"
+// @Failure 400 {string} string "Bad Request"
+// @Failure 401 {string} string "Unauthorized"
+// @Failure 500 {string} string "Internal Server Error"
+// @Router /refresh [post]
+func (h *userHandler) RefreshHandler(c *gin.Context) {
+	var incoming models.RefreshRequest
+	if err := c.ShouldBindJSON(&incoming); err != nil {
+		httperr.Write(c, http.StatusBadRequest, err.Error())
+		return
+	}
+	pair, err := h.svc.Refresh(c.Request.Context(), incoming.RefreshToken)
+	if err != nil {
+		switch {
+		case errors.Is(err, service.ErrInvalidRefresh), errors.Is(err, service.ErrRefreshReuse):
+			httperr.Write(c, http.StatusUnauthorized, "Invalid refresh token")
+		case errors.Is(err, service.ErrRefreshPersist), errors.Is(err, service.ErrTokenGenerate), errors.Is(err, service.ErrLoginDB):
+			httperr.Write(c, http.StatusInternalServerError, "Internal Server Error")
+		default:
+			httperr.Write(c, http.StatusInternalServerError, "Internal Server Error")
+		}
+		return
+	}
+	httpresp.OK(c, tokenPairBody(pair))
+}
+
+// LogoutHandler godoc
+// @Summary Log out and revoke tokens
+// @Schemes
+// @Description Revokes refresh token(s) for the authenticated user and denylists the current access JWT when Redis denylist is enabled
+// @Tags user
+// @Security ApiKeyAuth
+// @Security JwtAuth
+// @Accept  json
+// @Produce  json
+// @Param   body  body  models.LogoutRequest  false  "Optional refresh token to revoke a single family"
+// @Success 200 {object} models.LogoutAPIResponse "Logout confirmation"
+// @Failure 401 {string} string "Unauthorized"
+// @Failure 500 {string} string "Internal Server Error"
+// @Router /logout [post]
+func (h *userHandler) LogoutHandler(c *gin.Context) {
+	var incoming models.LogoutRequest
+	// Empty body is allowed; bind errors only when body is present but invalid JSON.
+	if c.Request.ContentLength != 0 {
+		if err := c.ShouldBindJSON(&incoming); err != nil {
+			httperr.Write(c, http.StatusBadRequest, err.Error())
+			return
+		}
+	}
+
+	userID, _ := c.Get(middleware.ContextUserID)
+	uid, _ := userID.(uint)
+	jtiVal, _ := c.Get(middleware.ContextJTI)
+	jti, _ := jtiVal.(string)
+	expVal, _ := c.Get(middleware.ContextAccessExp)
+	exp, _ := expVal.(time.Time)
+
+	if err := h.svc.Logout(c.Request.Context(), uid, incoming.RefreshToken, jti, exp); err != nil {
+		httperr.Write(c, http.StatusInternalServerError, "Internal Server Error")
+		return
+	}
+	httpresp.OK(c, models.LogoutSuccessBody{Message: "Logged out"})
 }
 
 // RegisterHandler godoc

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -3,44 +3,56 @@ package api
 import (
 	"bytes"
 	"encoding/json"
-	"golang-rest-api-template/pkg/auth"
-	"golang-rest-api-template/pkg/models"
-	"golang-rest-api-template/pkg/repository"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
 
-	"gorm.io/gorm"
+	"golang-rest-api-template/pkg/auth"
+	"golang-rest-api-template/pkg/middleware"
+	"golang-rest-api-template/pkg/models"
+	"golang-rest-api-template/pkg/repository"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
+
+func openUserTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "user.sqlite")), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.RefreshToken{}))
+	return db
+}
+
+func newTestUserHandler(db *gorm.DB) *userHandler {
+	return NewUserHandler(
+		repository.NewGormUserStore(db),
+		repository.NewGormRefreshTokenStore(db),
+		auth.NoopDenylist{},
+	)
+}
 
 func TestNewUserHandler(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	mockUsers := repository.NewMockUserPersistence(ctrl)
-
-	h := NewUserHandler(mockUsers)
-
+	h := NewUserHandler(mockUsers, nil, auth.NoopDenylist{})
 	assert.NotNil(t, h, "NewUserHandler should return a non-nil *userHandler")
 }
 
 func TestLoginHandlerSuccess(t *testing.T) {
-	// Set up real in-memory DB
-	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := db.AutoMigrate(&models.User{}); err != nil {
-		t.Fatal(err)
-	}
+	prev := auth.JWTSigningKey()
+	t.Cleanup(func() { _ = auth.SetJWTSigningKey(prev) })
+	require.NoError(t, auth.SetJWTSigningKey(bytes.Repeat([]byte("k"), auth.MinJWTSecretKeyBytes)))
 
-	h := NewUserHandler(repository.NewGormUserStore(db))
+	db := openUserTestDB(t)
+	h := newTestUserHandler(db)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -60,12 +72,13 @@ func TestLoginHandlerSuccess(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	var loginBody struct {
-		Data struct {
-			Token string `json:"token"`
-		} `json:"data"`
+		Data models.LoginTokenBody `json:"data"`
 	}
 	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &loginBody))
 	assert.NotEmpty(t, loginBody.Data.Token)
+	assert.Equal(t, loginBody.Data.Token, loginBody.Data.AccessToken)
+	assert.NotEmpty(t, loginBody.Data.RefreshToken)
+	assert.Greater(t, loginBody.Data.ExpiresIn, int64(0))
 }
 
 func TestLoginHandlerInvalidJSON(t *testing.T) {
@@ -73,7 +86,7 @@ func TestLoginHandlerInvalidJSON(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockUsers := repository.NewMockUserPersistence(ctrl)
-	h := NewUserHandler(mockUsers)
+	h := NewUserHandler(mockUsers, nil, auth.NoopDenylist{})
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -93,13 +106,12 @@ func TestLoginHandlerBindValidationLoginUser(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockUsers := repository.NewMockUserPersistence(ctrl)
-	h := NewUserHandler(mockUsers)
+	h := NewUserHandler(mockUsers, nil, auth.NoopDenylist{})
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
 	r.POST("/login", h.LoginHandler)
 
-	// Missing password — binding is on models.LoginUser, not models.User
 	body, _ := json.Marshal(map[string]string{"username": "onlyuser"})
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", "/login", bytes.NewBuffer(body))
@@ -111,16 +123,8 @@ func TestLoginHandlerBindValidationLoginUser(t *testing.T) {
 }
 
 func TestLoginHandlerUserNotFound(t *testing.T) {
-	// Set up real in-memory DB
-	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := db.AutoMigrate(&models.User{}); err != nil {
-		t.Fatal(err)
-	}
-
-	h := NewUserHandler(repository.NewGormUserStore(db))
+	db := openUserTestDB(t)
+	h := newTestUserHandler(db)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -139,16 +143,8 @@ func TestLoginHandlerUserNotFound(t *testing.T) {
 }
 
 func TestLoginHandlerWrongPassword(t *testing.T) {
-	// Set up real in-memory DB
-	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := db.AutoMigrate(&models.User{}); err != nil {
-		t.Fatal(err)
-	}
-
-	h := NewUserHandler(repository.NewGormUserStore(db))
+	db := openUserTestDB(t)
+	h := newTestUserHandler(db)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -170,12 +166,69 @@ func TestLoginHandlerWrongPassword(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "Invalid username or password")
 }
 
+func TestRefreshAndLogoutHandlers(t *testing.T) {
+	prev := auth.JWTSigningKey()
+	t.Cleanup(func() { _ = auth.SetJWTSigningKey(prev) })
+	require.NoError(t, auth.SetJWTSigningKey(bytes.Repeat([]byte("k"), auth.MinJWTSecretKeyBytes)))
+
+	db := openUserTestDB(t)
+	h := newTestUserHandler(db)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	r.POST("/login", h.LoginHandler)
+	r.POST("/refresh", h.RefreshHandler)
+	r.POST("/logout", middleware.JWTAuth(auth.NoopDenylist{}), h.LogoutHandler)
+
+	hashedPassword, _ := auth.HashPassword("password")
+	require.NoError(t, db.Create(&models.User{Username: "refreshuser", Password: hashedPassword}).Error)
+
+	loginBody, _ := json.Marshal(models.LoginUser{Username: "refreshuser", Password: "password"})
+	wLogin := httptest.NewRecorder()
+	reqLogin, _ := http.NewRequest("POST", "/login", bytes.NewBuffer(loginBody))
+	reqLogin.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(wLogin, reqLogin)
+	require.Equal(t, http.StatusOK, wLogin.Code)
+
+	var loginResp struct {
+		Data models.LoginTokenBody `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(wLogin.Body.Bytes(), &loginResp))
+
+	refreshBody, _ := json.Marshal(models.RefreshRequest{RefreshToken: loginResp.Data.RefreshToken})
+	wRefresh := httptest.NewRecorder()
+	reqRefresh, _ := http.NewRequest("POST", "/refresh", bytes.NewBuffer(refreshBody))
+	reqRefresh.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(wRefresh, reqRefresh)
+	require.Equal(t, http.StatusOK, wRefresh.Code)
+
+	var refreshResp struct {
+		Data models.LoginTokenBody `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(wRefresh.Body.Bytes(), &refreshResp))
+	assert.NotEqual(t, loginResp.Data.RefreshToken, refreshResp.Data.RefreshToken)
+
+	wLogout := httptest.NewRecorder()
+	reqLogout, _ := http.NewRequest("POST", "/logout", bytes.NewBuffer([]byte(`{}`)))
+	reqLogout.Header.Set("Content-Type", "application/json")
+	reqLogout.Header.Set("Authorization", "Bearer "+refreshResp.Data.AccessToken)
+	r.ServeHTTP(wLogout, reqLogout)
+	assert.Equal(t, http.StatusOK, wLogout.Code)
+
+	wRefresh2 := httptest.NewRecorder()
+	reuseBody, _ := json.Marshal(models.RefreshRequest{RefreshToken: refreshResp.Data.RefreshToken})
+	reqReuse, _ := http.NewRequest("POST", "/refresh", bytes.NewBuffer(reuseBody))
+	reqReuse.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(wRefresh2, reqReuse)
+	assert.Equal(t, http.StatusUnauthorized, wRefresh2.Code)
+}
+
 func TestRegisterHandlerInvalidJSON(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	mockUsers := repository.NewMockUserPersistence(ctrl)
-	h := NewUserHandler(mockUsers)
+	h := NewUserHandler(mockUsers, nil, auth.NoopDenylist{})
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -195,7 +248,7 @@ func TestRegisterHandlerDBError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockUsers := repository.NewMockUserPersistence(ctrl)
-	h := NewUserHandler(mockUsers)
+	h := NewUserHandler(mockUsers, nil, auth.NoopDenylist{})
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -227,7 +280,7 @@ func TestRegisterHandlerDuplicateUsername(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := NewUserHandler(repository.NewGormUserStore(db))
+	h := NewUserHandler(repository.NewGormUserStore(db), nil, auth.NoopDenylist{})
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
 	r.POST("/register", h.RegisterHandler)

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -135,6 +135,7 @@ func bcryptCostForPasswordHashing() int {
 // GenerateToken issues an HS256 JWT with username, user_id, and role claims.
 // userID must be non-zero (database primary key of the authenticated user).
 // role must be a known application role (see ValidRole).
+// The token includes jti and iat so logout can denylist the access token until exp.
 func GenerateToken(username string, userID uint, role string) (string, error) {
 	if userID == 0 {
 		return "", fmt.Errorf("auth.GenerateToken: user id must be non-zero")
@@ -149,13 +150,21 @@ func GenerateToken(username string, userID uint, role string) (string, error) {
 		return "", fmt.Errorf("auth.GenerateToken: %w", ErrJWTSigningKeyNotConfigured)
 	}
 
-	exp := time.Now().Add(5 * time.Minute)
+	jti, err := NewOpaqueToken()
+	if err != nil {
+		return "", fmt.Errorf("auth.GenerateToken: jti: %w", err)
+	}
+
+	now := time.Now()
+	exp := now.Add(AccessTokenTTL())
 	claims := &Claims{
 		Username: username,
 		UserID:   userID,
 		Role:     role,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(exp),
+			IssuedAt:  jwt.NewNumericDate(now),
+			ID:        jti,
 		},
 	}
 

--- a/pkg/auth/denylist.go
+++ b/pkg/auth/denylist.go
@@ -1,0 +1,104 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"golang-rest-api-template/pkg/cache"
+
+	"github.com/go-redis/redis/v8"
+)
+
+const denylistKeyPrefix = "v1:token_denylist:jti:"
+
+// TokenDenylist records revoked access-token JTIs until their natural expiry.
+type TokenDenylist interface {
+	// Deny marks jti as revoked until until (typically the JWT exp).
+	Deny(ctx context.Context, jti string, until time.Time) error
+	// IsDenied reports whether jti is currently revoked.
+	IsDenied(ctx context.Context, jti string) (bool, error)
+}
+
+// NoopDenylist never revokes or reports denials (used when denylist is disabled).
+type NoopDenylist struct{}
+
+// Deny implements TokenDenylist.
+func (NoopDenylist) Deny(context.Context, string, time.Time) error { return nil }
+
+// IsDenied implements TokenDenylist.
+func (NoopDenylist) IsDenied(context.Context, string) (bool, error) { return false, nil }
+
+// RedisDenylist stores revoked JTIs in Redis with TTL equal to remaining token life.
+type RedisDenylist struct {
+	cache cache.Cache
+}
+
+// NewRedisDenylist wraps c for jti denylist operations. c must be non-nil.
+func NewRedisDenylist(c cache.Cache) *RedisDenylist {
+	return &RedisDenylist{cache: c}
+}
+
+// Deny implements TokenDenylist.
+func (d *RedisDenylist) Deny(ctx context.Context, jti string, until time.Time) error {
+	if jti == "" {
+		return fmt.Errorf("auth: empty jti")
+	}
+	ttl := time.Until(until)
+	if ttl <= 0 {
+		return nil
+	}
+	key := denylistKeyPrefix + jti
+	if err := d.cache.Set(ctx, key, "1", ttl).Err(); err != nil {
+		return fmt.Errorf("auth: denylist set: %w", err)
+	}
+	return nil
+}
+
+// IsDenied implements TokenDenylist. Redis errors fail open (token not denied)
+// so availability is preserved when Redis is unavailable.
+func (d *RedisDenylist) IsDenied(ctx context.Context, jti string) (bool, error) {
+	if jti == "" {
+		return false, nil
+	}
+	_, err := d.cache.Get(ctx, denylistKeyPrefix+jti).Result()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return false, nil
+		}
+		log.Printf("auth: denylist get failed (fail-open): %v", err)
+		return false, nil
+	}
+	return true, nil
+}
+
+// TokenDenylistEnabled reports whether TOKEN_DENYLIST_ENABLED is affirmative.
+// Default is true when the variable is unset (denylist attempted when Redis is wired).
+func TokenDenylistEnabled() bool {
+	s := strings.TrimSpace(os.Getenv("TOKEN_DENYLIST_ENABLED"))
+	if s == "" {
+		return true
+	}
+	switch strings.ToLower(s) {
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	default:
+		log.Printf("auth: invalid TOKEN_DENYLIST_ENABLED=%q, treating as enabled", s)
+		return true
+	}
+}
+
+// NewTokenDenylistFromEnv returns a Redis-backed denylist when enabled and cache
+// is non-nil; otherwise a noop denylist. Auth flows never require Redis.
+func NewTokenDenylistFromEnv(c cache.Cache) TokenDenylist {
+	if !TokenDenylistEnabled() || c == nil {
+		return NoopDenylist{}
+	}
+	return NewRedisDenylist(c)
+}

--- a/pkg/auth/tokens.go
+++ b/pkg/auth/tokens.go
@@ -1,0 +1,67 @@
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	defaultAccessTokenTTL  = 5 * time.Minute
+	defaultRefreshTokenTTL = 7 * 24 * time.Hour
+	refreshTokenBytes      = 32
+	familyIDBytes          = 16
+)
+
+// AccessTokenTTL returns the access JWT lifetime from ACCESS_TOKEN_TTL or the default (5m).
+func AccessTokenTTL() time.Duration {
+	return durationFromEnv("ACCESS_TOKEN_TTL", defaultAccessTokenTTL)
+}
+
+// RefreshTokenTTL returns the refresh token lifetime from REFRESH_TOKEN_TTL or the default (7d).
+func RefreshTokenTTL() time.Duration {
+	return durationFromEnv("REFRESH_TOKEN_TTL", defaultRefreshTokenTTL)
+}
+
+func durationFromEnv(key string, def time.Duration) time.Duration {
+	s := strings.TrimSpace(os.Getenv(key))
+	if s == "" {
+		return def
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		log.Printf("auth: invalid %s=%q, using default %v", key, s, def)
+		return def
+	}
+	return d
+}
+
+// NewOpaqueToken returns a URL-safe random token string (base64 raw URL encoding).
+func NewOpaqueToken() (string, error) {
+	b := make([]byte, refreshTokenBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("auth: generate opaque token: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// NewFamilyID returns a random opaque family identifier for refresh token rotation chains.
+func NewFamilyID() (string, error) {
+	b := make([]byte, familyIDBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("auth: generate family id: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// HashRefreshToken returns the SHA-256 hex digest of the plaintext refresh token.
+func HashRefreshToken(plaintext string) string {
+	sum := sha256.Sum256([]byte(plaintext))
+	return hex.EncodeToString(sum[:])
+}

--- a/pkg/auth/tokens_test.go
+++ b/pkg/auth/tokens_test.go
@@ -1,0 +1,84 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHashRefreshTokenDeterministic(t *testing.T) {
+	a := HashRefreshToken("plain-token")
+	b := HashRefreshToken("plain-token")
+	assert.Equal(t, a, b)
+	assert.Len(t, a, 64)
+	assert.NotEqual(t, a, HashRefreshToken("other"))
+}
+
+func TestNewOpaqueTokenUnique(t *testing.T) {
+	a, err := NewOpaqueToken()
+	require.NoError(t, err)
+	b, err := NewOpaqueToken()
+	require.NoError(t, err)
+	assert.NotEqual(t, a, b)
+	assert.NotEmpty(t, a)
+}
+
+func TestNoopDenylist(t *testing.T) {
+	d := NoopDenylist{}
+	assert.NoError(t, d.Deny(context.Background(), "jti", time.Now().Add(time.Minute)))
+	denied, err := d.IsDenied(context.Background(), "jti")
+	assert.NoError(t, err)
+	assert.False(t, denied)
+}
+
+func TestTokenDenylistEnabledEnv(t *testing.T) {
+	t.Setenv("TOKEN_DENYLIST_ENABLED", "false")
+	assert.False(t, TokenDenylistEnabled())
+	t.Setenv("TOKEN_DENYLIST_ENABLED", "true")
+	assert.True(t, TokenDenylistEnabled())
+	t.Setenv("TOKEN_DENYLIST_ENABLED", "")
+	assert.True(t, TokenDenylistEnabled())
+}
+
+func TestNewTokenDenylistFromEnvNoopWhenDisabled(t *testing.T) {
+	t.Setenv("TOKEN_DENYLIST_ENABLED", "false")
+	dl := NewTokenDenylistFromEnv(nil)
+	_, ok := dl.(NoopDenylist)
+	assert.True(t, ok)
+}
+
+func TestAccessTokenTTLDefault(t *testing.T) {
+	t.Setenv("ACCESS_TOKEN_TTL", "")
+	assert.Equal(t, defaultAccessTokenTTL, AccessTokenTTL())
+	t.Setenv("ACCESS_TOKEN_TTL", "10m")
+	assert.Equal(t, 10*time.Minute, AccessTokenTTL())
+}
+
+func TestRefreshTokenTTLDefault(t *testing.T) {
+	t.Setenv("REFRESH_TOKEN_TTL", "")
+	assert.Equal(t, defaultRefreshTokenTTL, RefreshTokenTTL())
+	t.Setenv("REFRESH_TOKEN_TTL", "24h")
+	assert.Equal(t, 24*time.Hour, RefreshTokenTTL())
+}
+
+func TestGenerateTokenIncludesJTIAndIAT(t *testing.T) {
+	prev := JWTSigningKey()
+	t.Cleanup(func() { _ = SetJWTSigningKey(prev) })
+	require.NoError(t, SetJWTSigningKey(bytes.Repeat([]byte("k"), MinJWTSecretKeyBytes)))
+
+	tok, err := GenerateToken("u", 1, RoleUser)
+	require.NoError(t, err)
+
+	claims := &Claims{}
+	parsed, err := jwt.ParseWithClaims(tok, claims, JWTKeyFunc(JWTSigningKey()))
+	require.NoError(t, err)
+	require.True(t, parsed.Valid)
+	assert.NotEmpty(t, claims.ID)
+	assert.NotNil(t, claims.IssuedAt)
+	assert.NotNil(t, claims.ExpiresAt)
+}

--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -110,6 +110,11 @@ func NewDatabase() *gorm.DB {
 		return nil
 	}
 
+	if err := database.AutoMigrate(&models.RefreshToken{}); err != nil {
+		log.Printf("Failed to migrate RefreshToken model: %v", err)
+		return nil
+	}
+
 	if err := configureConnPool(database); err != nil {
 		log.Printf("Failed to configure SQL connection pool: %v", err)
 		return nil

--- a/pkg/database/db_test.go
+++ b/pkg/database/db_test.go
@@ -15,7 +15,7 @@ func setupSQLiteDB(t *testing.T) *gorm.DB {
 	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
 	assert.NoError(t, err)
 
-	err = db.AutoMigrate(&models.Book{}, &models.User{})
+	err = db.AutoMigrate(&models.Book{}, &models.User{}, &models.RefreshToken{})
 	assert.NoError(t, err)
 
 	return db

--- a/pkg/middleware/jwt_auth.go
+++ b/pkg/middleware/jwt_auth.go
@@ -18,10 +18,20 @@ const ContextUserID = "user_id"
 // set by JWTAuth after successful verification.
 const ContextRole = "role"
 
+// ContextJTI is the Gin context key for the access token jti claim.
+const ContextJTI = "jti"
+
+// ContextAccessExp is the Gin context key for the access token expiry time.Time.
+const ContextAccessExp = "access_exp"
+
 // JWTAuth returns Gin middleware that requires a valid Bearer JWT signed
 // with HMAC-SHA256 using the application's JWT secret. Other algorithms are
-// rejected before signature verification.
-func JWTAuth() gin.HandlerFunc {
+// rejected before signature verification. When denylist is non-nil, revoked
+// JTIs are rejected; a nil denylist skips the check (same as NoopDenylist).
+func JWTAuth(denylist auth.TokenDenylist) gin.HandlerFunc {
+	if denylist == nil {
+		denylist = auth.NoopDenylist{}
+	}
 	return func(c *gin.Context) {
 		const BearerSchema = "Bearer "
 		header := c.GetHeader("Authorization")
@@ -66,9 +76,25 @@ func JWTAuth() gin.HandlerFunc {
 			return
 		}
 
+		if claims.ID != "" {
+			denied, err := denylist.IsDenied(c.Request.Context(), claims.ID)
+			if err != nil {
+				httperr.Abort(c, http.StatusUnauthorized, "Invalid token")
+				return
+			}
+			if denied {
+				httperr.Abort(c, http.StatusUnauthorized, "Token revoked")
+				return
+			}
+		}
+
 		c.Set("username", claims.Username)
 		c.Set(ContextUserID, claims.UserID)
 		c.Set(ContextRole, claims.Role)
+		c.Set(ContextJTI, claims.ID)
+		if claims.ExpiresAt != nil {
+			c.Set(ContextAccessExp, claims.ExpiresAt.Time)
+		}
 		c.Next()
 	}
 }

--- a/pkg/middleware/jwt_auth_test.go
+++ b/pkg/middleware/jwt_auth_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"golang-rest-api-template/pkg/auth"
 	"net/http"
@@ -28,7 +29,7 @@ func testRouterJWTAuthOnly(t *testing.T) *gin.Engine {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	r.GET("/protected", JWTAuth(), func(c *gin.Context) {
+	r.GET("/protected", JWTAuth(auth.NoopDenylist{}), func(c *gin.Context) {
 		c.Status(http.StatusOK)
 	})
 	return r
@@ -101,7 +102,7 @@ func TestJWTAuthSetsUsernameContext(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	var got string
-	r.GET("/p", JWTAuth(), func(c *gin.Context) {
+	r.GET("/p", JWTAuth(auth.NoopDenylist{}), func(c *gin.Context) {
 		v, ok := c.Get("username")
 		if !ok {
 			t.Error("username not in context")
@@ -123,6 +124,42 @@ func TestJWTAuthSetsUsernameContext(t *testing.T) {
 	}
 }
 
+type mapDenylist struct {
+	denied map[string]bool
+}
+
+func (m mapDenylist) Deny(context.Context, string, time.Time) error { return nil }
+
+func (m mapDenylist) IsDenied(_ context.Context, jti string) (bool, error) {
+	return m.denied[jti], nil
+}
+
+func TestJWTAuthRejectsDenylistedJTI(t *testing.T) {
+	token, err := auth.GenerateToken("deny-user", 1, auth.RoleUser)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	claims := &auth.Claims{}
+	if _, err := jwt.ParseWithClaims(token, claims, auth.JWTKeyFunc(auth.JWTSigningKey())); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/p", JWTAuth(mapDenylist{denied: map[string]bool{claims.ID: true}}), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	req := httptest.NewRequest(http.MethodGet, "/p", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "Token revoked") {
+		t.Fatalf("body=%q", rec.Body.String())
+	}
+}
+
 func TestJWTAuthSetsUserIDContext(t *testing.T) {
 	const wantID uint = 77
 	token, err := auth.GenerateToken("uid-ctx-user", wantID, auth.RoleUser)
@@ -132,7 +169,7 @@ func TestJWTAuthSetsUserIDContext(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	var got uint
-	r.GET("/p", JWTAuth(), func(c *gin.Context) {
+	r.GET("/p", JWTAuth(auth.NoopDenylist{}), func(c *gin.Context) {
 		v, ok := c.Get(ContextUserID)
 		if !ok {
 			t.Error("user id not in context")
@@ -162,7 +199,7 @@ func TestJWTAuthSetsRoleContext(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	var got string
-	r.GET("/p", JWTAuth(), func(c *gin.Context) {
+	r.GET("/p", JWTAuth(auth.NoopDenylist{}), func(c *gin.Context) {
 		v, ok := c.Get(ContextRole)
 		if !ok {
 			t.Error("role not in context")

--- a/pkg/middleware/rbac_test.go
+++ b/pkg/middleware/rbac_test.go
@@ -16,7 +16,7 @@ func testRouterRequireRole(t *testing.T, allowed ...string) *gin.Engine {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	r.GET("/admin", JWTAuth(), RequireRole(allowed...), func(c *gin.Context) {
+	r.GET("/admin", JWTAuth(auth.NoopDenylist{}), RequireRole(allowed...), func(c *gin.Context) {
 		c.Status(http.StatusOK)
 	})
 	return r

--- a/pkg/models/api_json.go
+++ b/pkg/models/api_json.go
@@ -10,6 +10,16 @@ type LoginAPIResponse struct {
 	Data LoginTokenBody `json:"data"`
 }
 
+// RefreshAPIResponse documents POST /refresh 200 JSON.
+type RefreshAPIResponse struct {
+	Data LoginTokenBody `json:"data"`
+}
+
+// LogoutAPIResponse documents POST /logout 200 JSON.
+type LogoutAPIResponse struct {
+	Data LogoutSuccessBody `json:"data"`
+}
+
 // RegisterAPIResponse documents POST /register 201 JSON.
 type RegisterAPIResponse struct {
 	Data RegisterSuccessBody `json:"data"`

--- a/pkg/models/refresh_token.go
+++ b/pkg/models/refresh_token.go
@@ -1,0 +1,17 @@
+package models
+
+import "time"
+
+// RefreshToken is a persisted opaque refresh credential (hash only).
+// FamilyID groups rotated tokens so reuse of a consumed token can revoke the chain.
+type RefreshToken struct {
+	ID         uint       `json:"id" gorm:"primaryKey"`
+	UserID     uint       `json:"user_id" gorm:"index;not null"`
+	TokenHash  string     `json:"-" gorm:"uniqueIndex;size:64;not null"`
+	FamilyID   string     `json:"-" gorm:"index;size:64;not null"`
+	ExpiresAt  time.Time  `json:"expires_at" gorm:"index;not null"`
+	ConsumedAt *time.Time `json:"consumed_at,omitempty"`
+	RevokedAt  *time.Time `json:"revoked_at,omitempty"`
+	CreatedAt  time.Time  `json:"created_at" gorm:"autoCreateTime"`
+	UpdatedAt  time.Time  `json:"updated_at" gorm:"autoUpdateTime"`
+}

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -7,9 +7,30 @@ type LoginUser struct {
 	Password string `json:"password" binding:"required"`
 }
 
-// LoginTokenBody is the "data" object returned by POST /login on success.
+// LoginTokenBody is the "data" object returned by POST /login and POST /refresh on success.
+// Token is kept as an alias of AccessToken for backward compatibility with older clients.
 type LoginTokenBody struct {
-	Token string `json:"token"`
+	Token        string `json:"token"`
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int64  `json:"expires_in"`
+}
+
+// RefreshRequest is the JSON body for POST /refresh.
+type RefreshRequest struct {
+	RefreshToken string `json:"refresh_token" binding:"required"`
+}
+
+// LogoutRequest is the optional JSON body for POST /logout.
+// When RefreshToken is set, only that token family is revoked; otherwise all
+// refresh tokens for the authenticated user are revoked.
+type LogoutRequest struct {
+	RefreshToken string `json:"refresh_token"`
+}
+
+// LogoutSuccessBody is the "data" object returned by POST /logout on success.
+type LogoutSuccessBody struct {
+	Message string `json:"message"`
 }
 
 // RegisterSuccessBody is the "data" object returned by POST /register on success.

--- a/pkg/repository/mock_persistence.go
+++ b/pkg/repository/mock_persistence.go
@@ -180,3 +180,18 @@ func (mr *MockUserPersistenceMockRecorder) FindByUsername(username any) *gomock.
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByUsername", reflect.TypeOf((*MockUserPersistence)(nil).FindByUsername), username)
 }
+
+// FindByID mocks base method.
+func (m *MockUserPersistence) FindByID(id uint) (*models.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindByID", id)
+	ret0, _ := ret[0].(*models.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindByID indicates an expected call of FindByID.
+func (mr *MockUserPersistenceMockRecorder) FindByID(id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByID", reflect.TypeOf((*MockUserPersistence)(nil).FindByID), id)
+}

--- a/pkg/repository/refresh.go
+++ b/pkg/repository/refresh.go
@@ -1,0 +1,16 @@
+package repository
+
+import (
+	"time"
+
+	"golang-rest-api-template/pkg/models"
+)
+
+// RefreshTokenPersistence stores opaque refresh tokens (hashed) for rotation and revocation.
+type RefreshTokenPersistence interface {
+	Create(token *models.RefreshToken) error
+	FindByHash(tokenHash string) (*models.RefreshToken, error)
+	MarkConsumed(id uint, at time.Time) error
+	RevokeFamily(familyID string, at time.Time) error
+	RevokeAllForUser(userID uint, at time.Time) error
+}

--- a/pkg/repository/refresh_gorm.go
+++ b/pkg/repository/refresh_gorm.go
@@ -1,0 +1,49 @@
+package repository
+
+import (
+	"time"
+
+	"golang-rest-api-template/pkg/models"
+
+	"gorm.io/gorm"
+)
+
+// GormRefreshTokenStore implements RefreshTokenPersistence using GORM.
+type GormRefreshTokenStore struct {
+	db *gorm.DB
+}
+
+// NewGormRefreshTokenStore returns a RefreshTokenPersistence backed by db.
+func NewGormRefreshTokenStore(db *gorm.DB) *GormRefreshTokenStore {
+	return &GormRefreshTokenStore{db: db}
+}
+
+func (s *GormRefreshTokenStore) Create(token *models.RefreshToken) error {
+	return s.db.Create(token).Error
+}
+
+func (s *GormRefreshTokenStore) FindByHash(tokenHash string) (*models.RefreshToken, error) {
+	var t models.RefreshToken
+	if err := s.db.Where("token_hash = ?", tokenHash).First(&t).Error; err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+func (s *GormRefreshTokenStore) MarkConsumed(id uint, at time.Time) error {
+	return s.db.Model(&models.RefreshToken{}).Where("id = ?", id).Updates(map[string]interface{}{
+		"consumed_at": at,
+	}).Error
+}
+
+func (s *GormRefreshTokenStore) RevokeFamily(familyID string, at time.Time) error {
+	return s.db.Model(&models.RefreshToken{}).
+		Where("family_id = ? AND revoked_at IS NULL", familyID).
+		Updates(map[string]interface{}{"revoked_at": at}).Error
+}
+
+func (s *GormRefreshTokenStore) RevokeAllForUser(userID uint, at time.Time) error {
+	return s.db.Model(&models.RefreshToken{}).
+		Where("user_id = ? AND revoked_at IS NULL", userID).
+		Updates(map[string]interface{}{"revoked_at": at}).Error
+}

--- a/pkg/repository/refresh_gorm_test.go
+++ b/pkg/repository/refresh_gorm_test.go
@@ -1,0 +1,46 @@
+package repository
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang-rest-api-template/pkg/models"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestGormRefreshTokenStoreLifecycle(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "refresh.sqlite")
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.RefreshToken{}))
+
+	store := NewGormRefreshTokenStore(db)
+	now := time.Now().UTC().Truncate(time.Second)
+	row := &models.RefreshToken{
+		UserID:    1,
+		TokenHash: "abc123hash",
+		FamilyID:  "family-1",
+		ExpiresAt: now.Add(time.Hour),
+	}
+	require.NoError(t, store.Create(row))
+	assert.NotZero(t, row.ID)
+
+	found, err := store.FindByHash("abc123hash")
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), found.UserID)
+
+	require.NoError(t, store.MarkConsumed(found.ID, now))
+	found, err = store.FindByHash("abc123hash")
+	require.NoError(t, err)
+	require.NotNil(t, found.ConsumedAt)
+
+	require.NoError(t, store.RevokeFamily("family-1", now))
+	found, err = store.FindByHash("abc123hash")
+	require.NoError(t, err)
+	require.NotNil(t, found.RevokedAt)
+}

--- a/pkg/repository/user.go
+++ b/pkg/repository/user.go
@@ -5,5 +5,6 @@ import "golang-rest-api-template/pkg/models"
 // UserPersistence loads and stores users without HTTP or Gin.
 type UserPersistence interface {
 	FindByUsername(username string) (*models.User, error)
+	FindByID(id uint) (*models.User, error)
 	Create(user *models.User) error
 }

--- a/pkg/repository/user_gorm.go
+++ b/pkg/repository/user_gorm.go
@@ -28,6 +28,14 @@ func (s *GormUserStore) FindByUsername(username string) (*models.User, error) {
 	return &u, nil
 }
 
+func (s *GormUserStore) FindByID(id uint) (*models.User, error) {
+	var u models.User
+	if err := s.db.First(&u, id).Error; err != nil {
+		return nil, err
+	}
+	return &u, nil
+}
+
 func (s *GormUserStore) Create(user *models.User) error {
 	err := s.db.Create(user).Error
 	if err == nil {

--- a/pkg/service/user_service.go
+++ b/pkg/service/user_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"golang-rest-api-template/pkg/auth"
 	"golang-rest-api-template/pkg/models"
@@ -12,7 +13,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-// Sentinel errors for login / registration.
+// Sentinel errors for login / registration / token lifecycle.
 var (
 	ErrInvalidLogin     = errors.New("service: invalid username or password")
 	ErrLoginDB          = errors.New("service: login database error")
@@ -20,39 +21,132 @@ var (
 	ErrRegisterConflict = errors.New("service: username already taken")
 	ErrRegisterHash     = errors.New("service: password hash failed")
 	ErrRegisterSave     = errors.New("service: could not save user")
+	ErrInvalidRefresh   = errors.New("service: invalid refresh token")
+	ErrRefreshReuse     = errors.New("service: refresh token reuse detected")
+	ErrRefreshPersist   = errors.New("service: refresh token persistence failed")
+	ErrLogoutPersist    = errors.New("service: logout persistence failed")
 )
+
+// TokenPair is the access + refresh credential pair returned by login/refresh.
+type TokenPair struct {
+	AccessToken  string
+	RefreshToken string
+	ExpiresIn    int64
+}
 
 // UserService handles authentication use-cases without Gin.
 type UserService struct {
-	users repository.UserPersistence
+	users    repository.UserPersistence
+	refresh  repository.RefreshTokenPersistence
+	denylist auth.TokenDenylist
 }
 
-// NewUserService constructs a UserService.
-func NewUserService(users repository.UserPersistence) *UserService {
-	return &UserService{users: users}
+// NewUserService constructs a UserService. refresh and denylist may be nil only
+// for register-only tests; Login/Refresh/Logout require a non-nil refresh store.
+func NewUserService(users repository.UserPersistence, refresh repository.RefreshTokenPersistence, denylist auth.TokenDenylist) *UserService {
+	if denylist == nil {
+		denylist = auth.NoopDenylist{}
+	}
+	return &UserService{users: users, refresh: refresh, denylist: denylist}
 }
 
-// Login validates credentials and returns a JWT token string.
-func (s *UserService) Login(_ context.Context, username, password string) (token string, err error) {
+// Login validates credentials and returns an access JWT plus opaque refresh token.
+func (s *UserService) Login(ctx context.Context, username, password string) (TokenPair, error) {
+	var zero TokenPair
 	dbUser, err := s.users.FindByUsername(username)
 	if err != nil {
 		if repository.IsUserNotFound(err) {
-			return "", ErrInvalidLogin
+			return zero, ErrInvalidLogin
 		}
-		return "", fmtError(ErrLoginDB, err)
+		return zero, fmtError(ErrLoginDB, err)
 	}
 	if err := bcrypt.CompareHashAndPassword([]byte(dbUser.Password), []byte(password)); err != nil {
-		return "", ErrInvalidLogin
+		return zero, ErrInvalidLogin
 	}
-	role, err := auth.EffectiveRole(dbUser.Role)
+	return s.issueTokenPair(ctx, dbUser)
+}
+
+// Refresh rotates a refresh token and returns a new access + refresh pair.
+// Reuse of a consumed token revokes the entire family.
+func (s *UserService) Refresh(ctx context.Context, refreshPlaintext string) (TokenPair, error) {
+	var zero TokenPair
+	if s.refresh == nil {
+		return zero, ErrRefreshPersist
+	}
+	if refreshPlaintext == "" {
+		return zero, ErrInvalidRefresh
+	}
+
+	hash := auth.HashRefreshToken(refreshPlaintext)
+	row, err := s.refresh.FindByHash(hash)
 	if err != nil {
-		return "", fmtError(ErrTokenGenerate, err)
+		if repository.IsUserNotFound(err) {
+			return zero, ErrInvalidRefresh
+		}
+		return zero, fmtError(ErrRefreshPersist, err)
 	}
-	tok, err := auth.GenerateToken(dbUser.Username, dbUser.ID, role)
+
+	now := time.Now()
+	if row.RevokedAt != nil {
+		return zero, ErrInvalidRefresh
+	}
+	if row.ExpiresAt.Before(now) {
+		return zero, ErrInvalidRefresh
+	}
+	if row.ConsumedAt != nil {
+		_ = s.refresh.RevokeFamily(row.FamilyID, now)
+		return zero, ErrRefreshReuse
+	}
+
+	if err := s.refresh.MarkConsumed(row.ID, now); err != nil {
+		return zero, fmtError(ErrRefreshPersist, err)
+	}
+
+	dbUser, err := s.users.FindByID(row.UserID)
 	if err != nil {
-		return "", fmtError(ErrTokenGenerate, err)
+		if repository.IsUserNotFound(err) {
+			return zero, ErrInvalidRefresh
+		}
+		return zero, fmtError(ErrLoginDB, err)
 	}
-	return tok, nil
+	return s.issueTokenPairWithFamily(ctx, dbUser, row.FamilyID)
+}
+
+// Logout revokes refresh tokens and optionally denylists the current access jti.
+// If refreshPlaintext is non-empty, only that token's family is revoked; otherwise
+// all refresh tokens for userID are revoked.
+func (s *UserService) Logout(ctx context.Context, userID uint, refreshPlaintext, accessJTI string, accessExp time.Time) error {
+	if s.refresh == nil {
+		return ErrLogoutPersist
+	}
+	now := time.Now()
+
+	if refreshPlaintext != "" {
+		hash := auth.HashRefreshToken(refreshPlaintext)
+		row, err := s.refresh.FindByHash(hash)
+		if err != nil {
+			if !repository.IsUserNotFound(err) {
+				return fmtError(ErrLogoutPersist, err)
+			}
+			// Unknown refresh: still denylist access token and succeed.
+		} else if row.UserID == userID {
+			if err := s.refresh.RevokeFamily(row.FamilyID, now); err != nil {
+				return fmtError(ErrLogoutPersist, err)
+			}
+		}
+	} else {
+		if err := s.refresh.RevokeAllForUser(userID, now); err != nil {
+			return fmtError(ErrLogoutPersist, err)
+		}
+	}
+
+	if accessJTI != "" && !accessExp.IsZero() {
+		if err := s.denylist.Deny(ctx, accessJTI, accessExp); err != nil {
+			// Denylist is best-effort; refresh revocation already succeeded.
+			_ = err
+		}
+	}
+	return nil
 }
 
 // Register creates a new user account.
@@ -69,6 +163,49 @@ func (s *UserService) Register(_ context.Context, username, password string) err
 		return fmtError(ErrRegisterSave, err)
 	}
 	return nil
+}
+
+func (s *UserService) issueTokenPair(ctx context.Context, dbUser *models.User) (TokenPair, error) {
+	familyID, err := auth.NewFamilyID()
+	if err != nil {
+		return TokenPair{}, fmtError(ErrTokenGenerate, err)
+	}
+	return s.issueTokenPairWithFamily(ctx, dbUser, familyID)
+}
+
+func (s *UserService) issueTokenPairWithFamily(_ context.Context, dbUser *models.User, familyID string) (TokenPair, error) {
+	var zero TokenPair
+	role, err := auth.EffectiveRole(dbUser.Role)
+	if err != nil {
+		return zero, fmtError(ErrTokenGenerate, err)
+	}
+	access, err := auth.GenerateToken(dbUser.Username, dbUser.ID, role)
+	if err != nil {
+		return zero, fmtError(ErrTokenGenerate, err)
+	}
+
+	plain, err := auth.NewOpaqueToken()
+	if err != nil {
+		return zero, fmtError(ErrTokenGenerate, err)
+	}
+	if s.refresh == nil {
+		return zero, ErrRefreshPersist
+	}
+	row := &models.RefreshToken{
+		UserID:    dbUser.ID,
+		TokenHash: auth.HashRefreshToken(plain),
+		FamilyID:  familyID,
+		ExpiresAt: time.Now().Add(auth.RefreshTokenTTL()),
+	}
+	if err := s.refresh.Create(row); err != nil {
+		return zero, fmtError(ErrRefreshPersist, err)
+	}
+
+	return TokenPair{
+		AccessToken:  access,
+		RefreshToken: plain,
+		ExpiresIn:    int64(auth.AccessTokenTTL().Seconds()),
+	}, nil
 }
 
 func fmtError(sentinel error, cause error) error {

--- a/pkg/service/user_service_test.go
+++ b/pkg/service/user_service_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"golang-rest-api-template/pkg/auth"
 	"golang-rest-api-template/pkg/models"
@@ -13,13 +15,15 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 )
 
 type fakeUserStore struct {
-	findFn   func(username string) (*models.User, error)
-	createFn func(user *models.User) error
+	findFn     func(username string) (*models.User, error)
+	findByIDFn func(id uint) (*models.User, error)
+	createFn   func(user *models.User) error
 }
 
 func (f *fakeUserStore) FindByUsername(username string) (*models.User, error) {
@@ -29,11 +33,87 @@ func (f *fakeUserStore) FindByUsername(username string) (*models.User, error) {
 	return nil, nil
 }
 
+func (f *fakeUserStore) FindByID(id uint) (*models.User, error) {
+	if f.findByIDFn != nil {
+		return f.findByIDFn(id)
+	}
+	return nil, gorm.ErrRecordNotFound
+}
+
 func (f *fakeUserStore) Create(user *models.User) error {
 	if f.createFn != nil {
 		return f.createFn(user)
 	}
 	return nil
+}
+
+type memRefreshStore struct {
+	mu     sync.Mutex
+	byHash map[string]*models.RefreshToken
+	nextID uint
+}
+
+func newMemRefreshStore() *memRefreshStore {
+	return &memRefreshStore{byHash: make(map[string]*models.RefreshToken)}
+}
+
+func (m *memRefreshStore) Create(token *models.RefreshToken) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.nextID++
+	cp := *token
+	cp.ID = m.nextID
+	m.byHash[cp.TokenHash] = &cp
+	return nil
+}
+
+func (m *memRefreshStore) FindByHash(tokenHash string) (*models.RefreshToken, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	t, ok := m.byHash[tokenHash]
+	if !ok {
+		return nil, gorm.ErrRecordNotFound
+	}
+	cp := *t
+	return &cp, nil
+}
+
+func (m *memRefreshStore) MarkConsumed(id uint, at time.Time) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, t := range m.byHash {
+		if t.ID == id {
+			t.ConsumedAt = &at
+			return nil
+		}
+	}
+	return gorm.ErrRecordNotFound
+}
+
+func (m *memRefreshStore) RevokeFamily(familyID string, at time.Time) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, t := range m.byHash {
+		if t.FamilyID == familyID && t.RevokedAt == nil {
+			t.RevokedAt = &at
+		}
+	}
+	return nil
+}
+
+func (m *memRefreshStore) RevokeAllForUser(userID uint, at time.Time) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, t := range m.byHash {
+		if t.UserID == userID && t.RevokedAt == nil {
+			t.RevokedAt = &at
+		}
+	}
+	return nil
+}
+
+func testUserService(users repository.UserPersistence, refresh repository.RefreshTokenPersistence) *UserService {
+	return NewUserService(users, refresh, auth.NoopDenylist{})
 }
 
 func TestUserServiceLoginUserNotFound(t *testing.T) {
@@ -42,7 +122,7 @@ func TestUserServiceLoginUserNotFound(t *testing.T) {
 			return nil, gorm.ErrRecordNotFound
 		},
 	}
-	svc := NewUserService(store)
+	svc := testUserService(store, newMemRefreshStore())
 	_, err := svc.Login(context.Background(), "nobody", "pw")
 	assert.ErrorIs(t, err, ErrInvalidLogin)
 }
@@ -55,7 +135,7 @@ func TestUserServiceLoginWrongPassword(t *testing.T) {
 			return &models.User{Username: "u", Password: string(hash)}, nil
 		},
 	}
-	svc := NewUserService(store)
+	svc := testUserService(store, newMemRefreshStore())
 	_, err = svc.Login(context.Background(), "u", "wrong")
 	assert.ErrorIs(t, err, ErrInvalidLogin)
 }
@@ -67,7 +147,7 @@ func TestUserServiceLoginDBError(t *testing.T) {
 			return nil, dbErr
 		},
 	}
-	svc := NewUserService(store)
+	svc := testUserService(store, newMemRefreshStore())
 	_, err := svc.Login(context.Background(), "u", "p")
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrLoginDB)
@@ -85,10 +165,12 @@ func TestUserServiceLoginSuccess(t *testing.T) {
 			return &models.User{ID: 100, Username: "alice", Password: string(hash), Role: auth.RoleUser}, nil
 		},
 	}
-	svc := NewUserService(store)
-	tok, err := svc.Login(context.Background(), "alice", "secret")
+	svc := testUserService(store, newMemRefreshStore())
+	pair, err := svc.Login(context.Background(), "alice", "secret")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, tok)
+	assert.NotEmpty(t, pair.AccessToken)
+	assert.NotEmpty(t, pair.RefreshToken)
+	assert.Greater(t, pair.ExpiresIn, int64(0))
 }
 
 func TestUserServiceLoginEmbedsAdminRole(t *testing.T) {
@@ -103,15 +185,16 @@ func TestUserServiceLoginEmbedsAdminRole(t *testing.T) {
 			return &models.User{ID: 3, Username: "boss", Password: string(hash), Role: auth.RoleAdmin}, nil
 		},
 	}
-	svc := NewUserService(store)
-	tok, err := svc.Login(context.Background(), "boss", "secret")
+	svc := testUserService(store, newMemRefreshStore())
+	pair, err := svc.Login(context.Background(), "boss", "secret")
 	assert.NoError(t, err)
 
 	parsed := &auth.Claims{}
-	token, err := jwt.ParseWithClaims(tok, parsed, auth.JWTKeyFunc(auth.JWTSigningKey()))
+	token, err := jwt.ParseWithClaims(pair.AccessToken, parsed, auth.JWTKeyFunc(auth.JWTSigningKey()))
 	assert.NoError(t, err)
 	assert.True(t, token.Valid)
 	assert.Equal(t, auth.RoleAdmin, parsed.Role)
+	assert.NotEmpty(t, parsed.ID)
 }
 
 func TestUserServiceLoginEmptyRoleDefaultsToUser(t *testing.T) {
@@ -126,14 +209,77 @@ func TestUserServiceLoginEmptyRoleDefaultsToUser(t *testing.T) {
 			return &models.User{ID: 4, Username: "legacy", Password: string(hash), Role: ""}, nil
 		},
 	}
-	svc := NewUserService(store)
-	tok, err := svc.Login(context.Background(), "legacy", "secret")
+	svc := testUserService(store, newMemRefreshStore())
+	pair, err := svc.Login(context.Background(), "legacy", "secret")
 	assert.NoError(t, err)
 
 	parsed := &auth.Claims{}
-	_, err = jwt.ParseWithClaims(tok, parsed, auth.JWTKeyFunc(auth.JWTSigningKey()))
+	_, err = jwt.ParseWithClaims(pair.AccessToken, parsed, auth.JWTKeyFunc(auth.JWTSigningKey()))
 	assert.NoError(t, err)
 	assert.Equal(t, auth.RoleUser, parsed.Role)
+}
+
+func TestUserServiceRefreshRotationAndReuse(t *testing.T) {
+	prev := auth.JWTSigningKey()
+	t.Cleanup(func() { _ = auth.SetJWTSigningKey(prev) })
+	require.NoError(t, auth.SetJWTSigningKey(bytes.Repeat([]byte("s"), auth.MinJWTSecretKeyBytes)))
+
+	hash, err := bcrypt.GenerateFromPassword([]byte("secret"), bcrypt.MinCost)
+	require.NoError(t, err)
+	user := &models.User{ID: 9, Username: "rot", Password: string(hash), Role: auth.RoleUser}
+	users := &fakeUserStore{
+		findFn: func(username string) (*models.User, error) {
+			return user, nil
+		},
+		findByIDFn: func(id uint) (*models.User, error) {
+			if id == user.ID {
+				return user, nil
+			}
+			return nil, gorm.ErrRecordNotFound
+		},
+	}
+	refresh := newMemRefreshStore()
+	svc := testUserService(users, refresh)
+
+	pair, err := svc.Login(context.Background(), "rot", "secret")
+	require.NoError(t, err)
+	oldRefresh := pair.RefreshToken
+
+	next, err := svc.Refresh(context.Background(), oldRefresh)
+	require.NoError(t, err)
+	assert.NotEqual(t, oldRefresh, next.RefreshToken)
+	assert.NotEmpty(t, next.AccessToken)
+
+	_, err = svc.Refresh(context.Background(), oldRefresh)
+	assert.ErrorIs(t, err, ErrRefreshReuse)
+}
+
+func TestUserServiceLogoutRevokesRefresh(t *testing.T) {
+	prev := auth.JWTSigningKey()
+	t.Cleanup(func() { _ = auth.SetJWTSigningKey(prev) })
+	require.NoError(t, auth.SetJWTSigningKey(bytes.Repeat([]byte("s"), auth.MinJWTSecretKeyBytes)))
+
+	hash, err := bcrypt.GenerateFromPassword([]byte("secret"), bcrypt.MinCost)
+	require.NoError(t, err)
+	user := &models.User{ID: 11, Username: "out", Password: string(hash), Role: auth.RoleUser}
+	users := &fakeUserStore{
+		findFn: func(string) (*models.User, error) { return user, nil },
+		findByIDFn: func(id uint) (*models.User, error) {
+			if id == user.ID {
+				return user, nil
+			}
+			return nil, gorm.ErrRecordNotFound
+		},
+	}
+	refresh := newMemRefreshStore()
+	svc := testUserService(users, refresh)
+
+	pair, err := svc.Login(context.Background(), "out", "secret")
+	require.NoError(t, err)
+
+	require.NoError(t, svc.Logout(context.Background(), user.ID, "", "jti-1", time.Now().Add(time.Minute)))
+	_, err = svc.Refresh(context.Background(), pair.RefreshToken)
+	assert.ErrorIs(t, err, ErrInvalidRefresh)
 }
 
 func TestUserServiceRegisterSetsUserRole(t *testing.T) {
@@ -144,7 +290,7 @@ func TestUserServiceRegisterSetsUserRole(t *testing.T) {
 			return nil
 		},
 	}
-	svc := NewUserService(store)
+	svc := testUserService(store, newMemRefreshStore())
 	err := svc.Register(context.Background(), "newbie", "password123")
 	assert.NoError(t, err)
 	if assert.NotNil(t, created) {
@@ -158,7 +304,7 @@ func TestUserServiceRegisterConflictDuplicatedKey(t *testing.T) {
 			return fmt.Errorf("%w: %v", repository.ErrUserUsernameConflict, gorm.ErrDuplicatedKey)
 		},
 	}
-	svc := NewUserService(store)
+	svc := testUserService(store, newMemRefreshStore())
 	err := svc.Register(context.Background(), "dup", "password123")
 	assert.ErrorIs(t, err, ErrRegisterConflict)
 }
@@ -170,7 +316,7 @@ func TestUserServiceRegisterSaveError(t *testing.T) {
 			return saveErr
 		},
 	}
-	svc := NewUserService(store)
+	svc := testUserService(store, newMemRefreshStore())
 	err := svc.Register(context.Background(), "u", "password123")
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrRegisterSave)

--- a/tests/e2e.py
+++ b/tests/e2e.py
@@ -39,8 +39,11 @@ def get_jwt_token():
     # Extracting JWT token from login response (standard envelope)
     body = login_response.json()
     data = body.get("data") or {}
-    jwt_token = data.get("token") if isinstance(data, dict) else None
+    jwt_token = None
+    if isinstance(data, dict):
+        jwt_token = data.get("access_token") or data.get("token")
     assert jwt_token is not None, "JWT token not found in login response"
+    assert data.get("refresh_token"), "refresh_token not found in login response"
 
     return jwt_token
 


### PR DESCRIPTION
## Summary

Implements [#140](https://github.com/LAA-Software-Engineering/golang-rest-api-template/issues/140): short-lived access JWTs pair with opaque Postgres refresh tokens (rotation + family reuse detection). Logout revokes refresh rows and optionally denylists access JWT `jti` values in Redis until expiry.

- `POST /login` returns `access_token`, `refresh_token`, `expires_in` (keeps legacy `token` alias)
- `POST /refresh` rotates refresh tokens; reuse of a consumed token revokes the family
- `POST /logout` (API key + Bearer JWT) revokes refresh tokens; Redis denylist is opt-out via `TOKEN_DENYLIST_ENABLED`
- Works without Redis: login/refresh/logout use Postgres; access JWTs remain valid until natural expiry when denylist is off/unavailable

## Type of change

- [ ] Bug fix
- [ ] Refactor
- [x] New feature
- [ ] Breaking change (describe impact below)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Dependency update

## How to test

```bash
go test ./... -race
```

```bash
# optional: local stack
# make up

# optional: Python E2E (see README; requires BASE_URL and API_KEY)
# pytest -v tests/e2e.py
```

Manual auth smoke (with API key):

1. `POST /api/v1/register` then `POST /api/v1/login` — confirm `data.access_token` and `data.refresh_token`
2. `POST /api/v1/refresh` with the refresh token — confirm rotation
3. Reuse the old refresh token — expect `401`
4. `POST /api/v1/logout` with Bearer access JWT — refresh should fail afterward
5. With `TOKEN_DENYLIST_ENABLED=false`, logout still revokes refresh; access JWT may work until `exp`

## Checklist

- [x] `go test ./... -race` passes locally
- [x] If you changed **routes, handlers, or models**: Swagger was regenerated (`swag init` / project `Makefile` `setup` target) and `docs/` is updated if required
- [x] If you added or renamed **environment variables**: README and/or `.env` examples are updated
- [ ] If you changed **Docker or compose**: `docker compose build` (or `make build-docker`) still succeeds
- [x] No new secrets, credentials, or production keys committed

## Related issues

Closes #140

Made with [Cursor](https://cursor.com)